### PR TITLE
Make sure root files are closed (VEGAS)

### DIFF
--- a/pyV2DL3/vegas/VegasDataSource.py
+++ b/pyV2DL3/vegas/VegasDataSource.py
@@ -20,6 +20,11 @@ class VegasDataSource(VtsDataSource):
         self.__zenith__ = 0
         self.__noise__ = 0
 
+    def __del__(self):
+        # Close the root files
+        self.__evt_file__.closeTheRootFile()
+        self.__ea_file__.closeTheRootFile()
+
     def __fill_evt__(self):
         gti, ea_config, evts = __fillEVENTS_not_safe__(self.__evt_file__)
         self.__gti__ = gti


### PR DESCRIPTION
This PR resolves issue #38. 

The solution was to add a `VegasDataSource.__del__()` method and call 'closeTheRootFile' on the event and eff-area files. This ensures these files get closed regardless of what VEGAS is doing whenever the 'VegasDataSource' object is cleaned up.