### PR TITLE
Add root_numpy back into setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'scipy',
         'tqdm',
         'uproot',
+        'root_numpy'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
There are dependencies on root_numpy on the vegas side, so we need this here.