### PR TITLE
bug fixed in writting hdu_class_type for `EDISP`

### DIFF
--- a/pyV2DL3/generateObsHduIndex.py
+++ b/pyV2DL3/generateObsHduIndex.py
@@ -12,7 +12,7 @@ hdu_class_type = {
     ("EVENTS", None): ("events", "events"),
     ("GTI", None): ("gti", "gti"),
     ("RESPONSE", "EFF_AREA"): ("aeff", "aeff_2d"),
-    ("RESPONSE", "EDISP"): ("aeff", "edisp_2d"),
+    ("RESPONSE", "EDISP"): ("edisp", "edisp_2d"),
     ("RESPONSE", "PSF"): ("psf", None),
     ("RESPONSE", "BKG"): ("bkg", None),
 }


### PR DESCRIPTION
This resolves the error of `Found multiple HDU matching` for given `OBS_ID` in gammapy-0.19