### PR TITLE
Minor updates to allow static code tests to give reasonable results.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,10 +38,12 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh
           conda activate v2dl3ED
           conda install flake8
-          flake8 . --count --select=E9,F63,F7,F82 --ignore=E203,W503 \
-                   --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=25 --ignore=E203,W503 \
-                   --max-line-length=127 --statistics
+          flake8 --count --select=E9,F63,F7,F82 --ignore=E203,W503 \
+                   --show-source --statistics .
+          # ignore vegas for static code test
+          flake8 --count --max-complexity=25 --ignore=E203,W503 \
+                 --max-line-length=127 --statistics \
+                 --extend-exclude vegas .
 
       - name: pytest
         shell: bash -leo pipefail {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,9 +38,10 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh
           conda activate v2dl3ED
           conda install flake8
-          #flake8 . --count --exit-zero --max-line-length=90 --ignore=E203,W503 --select=W504 --show-source --statistics
-          flake8 . --count --select=E9,F63,F7,F82 --ignore=E203,W503 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=25 --ignore=E203,W503 --max-line-length=127 --statistics
+          flake8 . --count --select=E9,F63,F7,F82 --ignore=E203,W503 \
+                   --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=25 --ignore=E203,W503 \
+                   --max-line-length=127 --statistics
 
       - name: pytest
         shell: bash -leo pipefail {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,10 +40,8 @@ jobs:
           conda install flake8
           flake8 --count --select=E9,F63,F7,F82 --ignore=E203,W503 \
                    --show-source --statistics .
-          # ignore vegas for static code test
           flake8 --count --max-complexity=25 --ignore=E203,W503 \
-                 --max-line-length=127 --statistics \
-                 --extend-exclude vegas .
+                 --max-line-length=127 --statistics .
 
       - name: pytest
         shell: bash -leo pipefail {0}

--- a/notebooks/eventdisplay-testing/compareFitsFiles.py
+++ b/notebooks/eventdisplay-testing/compareFitsFiles.py
@@ -5,18 +5,20 @@
 from astropy.io import fits
 import click
 
-CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--file_pair', '-f', nargs=2, type=click.Path(exists=True),
-              help='pair of fits files to be compared')
-@click.option('--diff_file', '-d', nargs=1,
-              help='summary of differences')
+@click.option(
+    "--file_pair",
+    "-f",
+    nargs=2,
+    type=click.Path(exists=True),
+    help="pair of fits files to be compared",
+)
+@click.option("--diff_file", "-d", nargs=1, help="summary of differences")
 def cli(file_pair, diff_file):
-    """Difference report of two FITS files
-
-    """
+    """Difference report of two FITS files"""
 
     if not file_pair or len(file_pair) == 0:
         click.echo(cli.get_help(click.Context(cli)))
@@ -28,5 +30,5 @@ def cli(file_pair, diff_file):
     fd.report(diff_file, overwrite=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/notebooks/gammapy_util.py
+++ b/notebooks/gammapy_util.py
@@ -4,9 +4,9 @@ import os
 
 
 def getDSfromList(flist):
-    hdu_index = gen_hdu_index(flist, os.path.realpath('./'))
-    obs_index = gen_obs_index(flist, os.path.realpath('./'))
-    hdu_index.meta['BASE_DIR'] = os.path.realpath('./')
+    hdu_index = gen_hdu_index(flist, os.path.realpath("./"))
+    obs_index = gen_obs_index(flist, os.path.realpath("./"))
+    hdu_index.meta["BASE_DIR"] = os.path.realpath("./")
     return DataStore(
         hdu_table=HDUIndexTable(hdu_index),
         obs_table=ObservationTable(obs_index),

--- a/notebooks/gammapy_util.py
+++ b/notebooks/gammapy_util.py
@@ -1,6 +1,9 @@
-from gammapy.data import HDUIndexTable, ObservationTable, DataStore
-from pyV2DL3.generateObsHduIndex import gen_hdu_index, gen_obs_index
+from gammapy.data import DataStore
+from gammapy.data import HDUIndexTable
+from gammapy.data import ObservationTable
 import os
+from pyV2DL3.generateObsHduIndex import gen_hdu_index
+from pyV2DL3.generateObsHduIndex import gen_obs_index
 
 
 def getDSfromList(flist):

--- a/pyV2DL3/eventdisplay/EventDisplayDataSource.py
+++ b/pyV2DL3/eventdisplay/EventDisplayDataSource.py
@@ -1,8 +1,8 @@
 import logging
 
-from pyV2DL3.VtsDataSource import VtsDataSource
 from pyV2DL3.eventdisplay.fillEVENTS import __fillEVENTS__
 from pyV2DL3.eventdisplay.fillRESPONSE import __fillRESPONSE__
+from pyV2DL3.VtsDataSource import VtsDataSource
 
 
 class EventDisplayDataSource(VtsDataSource):

--- a/pyV2DL3/eventdisplay/fillEVENTS.py
+++ b/pyV2DL3/eventdisplay/fillEVENTS.py
@@ -1,8 +1,8 @@
 import logging
 
+from astropy.time import Time
 import numpy as np
 import uproot
-from astropy.time import Time
 
 from pyV2DL3.constant import VTS_REFERENCE_HEIGHT
 from pyV2DL3.constant import VTS_REFERENCE_LAT

--- a/pyV2DL3/eventdisplay/util.py
+++ b/pyV2DL3/eventdisplay/util.py
@@ -131,7 +131,7 @@ def getRunQuality(logdata, ntel=4):
 
     """
 
-    vpm = 2 ** (ntel + 3) - 2 ** 3
+    vpm = 2 ** (ntel + 3) - 2**3
     if np.size(logdata) <= 1:
         return vpm
 

--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -2,8 +2,8 @@ import logging
 
 from astropy.io import fits
 
-import pyV2DL3.constant
 from pyV2DL3.addHDUClassKeyword import addHDUClassKeyword
+import pyV2DL3.constant
 
 
 def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None):

--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -1,10 +1,10 @@
 import logging
 
-from astropy.io import fits
 
 from pyV2DL3.addHDUClassKeyword import addHDUClassKeyword
 import pyV2DL3.constant
 
+from astropy.io import fits
 
 def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None):
 

--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -1,10 +1,10 @@
 import logging
 
+from astropy.io import fits
 
 from pyV2DL3.addHDUClassKeyword import addHDUClassKeyword
 import pyV2DL3.constant
 
-from astropy.io import fits
 
 def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None):
 

--- a/pyV2DL3/gammapy_util.py
+++ b/pyV2DL3/gammapy_util.py
@@ -1,8 +1,11 @@
 import os
 
-from gammapy.data import HDUIndexTable, ObservationTable, DataStore
+from gammapy.data import DataStore
+from gammapy.data import HDUIndexTable
+from gammapy.data import ObservationTable
 
-from pyV2DL3.generateObsHduIndex import gen_hdu_index, gen_obs_index
+from pyV2DL3.generateObsHduIndex import gen_hdu_index
+from pyV2DL3.generateObsHduIndex import gen_obs_index
 
 
 def getDSfromList(flist):

--- a/pyV2DL3/script/v2dl3_qsub.py
+++ b/pyV2DL3/script/v2dl3_qsub.py
@@ -3,9 +3,9 @@ Submit v2dl3 EventDisplay jobs to batch farm. Uses input from script that contai
 The required script is created using the script ANALYSIS.anasum_parallel_from_runlist_v2dl3.sh.
 """
 
+from datetime import date
 import os
 import subprocess
-from datetime import date
 
 import click
 
@@ -52,7 +52,7 @@ def cli(v2dl3_script, conda_env, conda_exe, rootsys, add_option):
     conda_exe = os.path.expandvars(conda_exe)
     rootsys = os.path.expandvars(rootsys)
     logdir = os.path.expandvars(f"$VERITAS_USER_LOG_DIR/v2dl3/{today}")
-    qsub_cmd = f"qsub -t 1"
+    qsub_cmd = f'{"qsub -t 1"}'
 
     for ii, command in enumerate(commands):
         runnumber = command.split("/")[-1].split(".")[0]

--- a/pyV2DL3/vegas/VegasDataSource.py
+++ b/pyV2DL3/vegas/VegasDataSource.py
@@ -1,9 +1,9 @@
 import ROOT
 
-from pyV2DL3.VtsDataSource import VtsDataSource
 from pyV2DL3.vegas.fillEVENTS_not_safe import __fillEVENTS_not_safe__
 from pyV2DL3.vegas.fillRESPONSE_not_safe import __fillRESPONSE_not_safe__
 from pyV2DL3.vegas.load_vegas import VEGASStatus
+from pyV2DL3.VtsDataSource import VtsDataSource
 
 
 class VegasDataSource(VtsDataSource):

--- a/pyV2DL3/vegas/fillEVENTS_not_safe.py
+++ b/pyV2DL3/vegas/fillEVENTS_not_safe.py
@@ -1,11 +1,14 @@
 import logging
 
-import numpy as np
 from astropy.time import Time
+import numpy as np
 
 from pyV2DL3.constant import VTS_REFERENCE_MJD
-from pyV2DL3.vegas.util import getGTArray, getTimeCut, mergeTimeCut
-from pyV2DL3.vegas.util import produceTelList, decodeConfigMask
+from pyV2DL3.vegas.util import decodeConfigMask
+from pyV2DL3.vegas.util import getGTArray
+from pyV2DL3.vegas.util import getTimeCut
+from pyV2DL3.vegas.util import mergeTimeCut
+from pyV2DL3.vegas.util import produceTelList
 
 logger = logging.getLogger(__name__)
 

--- a/pyV2DL3/vegas/irfloader.py
+++ b/pyV2DL3/vegas/irfloader.py
@@ -1,9 +1,9 @@
-import logging
 from bisect import bisect_left
 from ctypes import c_float
+import logging
 
-import ROOT
 import numpy as np
+import ROOT
 from root_numpy import hist2array
 from scipy.interpolate import RegularGridInterpolator
 

--- a/pyV2DL3/vegas/util.py
+++ b/pyV2DL3/vegas/util.py
@@ -26,9 +26,7 @@ def produceTelList(mask):
 
 
 def parseTimeCut(tCutStr):
-    """
-    Parse time cuts from time cut text
-    """
+    """Parse time cuts from time cut text"""
     cut_arr = []
     for cc in tCutStr.split(","):
         start = float(cc.split("/")[0])
@@ -38,9 +36,7 @@ def parseTimeCut(tCutStr):
 
 
 def getTimeCut(config_str_ori):
-    """
-    Get time cut from extracted cut config text.
-    """
+    """Get time cut from extracted cut config text."""
     config_str = str(config_str_ori)
     for i in config_str.splitlines():
         # Skip comment lines
@@ -69,9 +65,7 @@ def getThetaSquareCut(config_str_ori):
 
 
 def isMergable(cut1, cut2):
-    """
-    Check if two cuts can be merged.
-    """
+    """Check if two cuts can be merged."""
     s1, e1 = cut1
     s2, e2 = cut2
     if s1 > s2:
@@ -81,9 +75,7 @@ def isMergable(cut1, cut2):
 
 
 def mergeTwoTimeCut(cut1, cut2):
-    """
-    Merge two cuts.
-    """
+    """Merge two cuts."""
     s1, e1 = cut1
     s2, e2 = cut2
     if s1 > s2:
@@ -93,9 +85,7 @@ def mergeTwoTimeCut(cut1, cut2):
 
 
 def mergeTimeCut(cuts):
-    """
-    Go through each cut and merge
-    """
+    """Go through each cut and merge"""
     cut_sorted = sorted(cuts)
     merged_cut = []
     while len(cut_sorted) > 0:
@@ -115,9 +105,7 @@ def mergeTimeCut(cuts):
 
 
 def getGTArray(startTime_s, endTime_s, cuts):
-    """
-    Produc Good Time Interval start and stop time array.
-    """
+    """Produce Good Time Interval start and stop time array."""
     if len(cuts) == 0:
         return np.array([startTime_s]), np.array([endTime_s])
     goodTimeStart = [startTime_s] + [cc[1] + startTime_s for cc in cuts]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 
 setup(
     name="pyV2DL3",

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,24 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='pyV2DL3',
-    version='0.1',
+    name="pyV2DL3",
+    version="0.1",
     packages=find_packages(),
     install_requires=[
-        'astropy',
-        'click',
-        'numpy',
-        'pkgconfig',
-        'pyyaml',
-        'scipy',
-        'tqdm',
-        'uproot',
-        'root_numpy'
+        "astropy",
+        "click",
+        "numpy",
+        "pkgconfig",
+        "pyyaml",
+        "scipy",
+        "tqdm",
+        "uproot",
+        "root_numpy",
     ],
-    entry_points='''
+    entry_points="""
         [console_scripts]
         v2dl3=pyV2DL3.script.v2dl3:cli
         v2dl3_qsub=pyV2DL3.script.v2dl3_qsub:cli
         generate_index_file=pyV2DL3.script.generate_index_file:cli
-    '''
+    """,
 )


### PR DESCRIPTION
Enabled  static code checking with flake8 in CI:
- CI will fail now when flake8 is not executed successfully (before: used `--exit-zero`)
- adapted several files to follow standards (mostly sequence of imports and docstrings)