### PR TITLE
remove unused parameter 'offset' 

### DIFF
--- a/pyV2DL3/eventdisplay/EventDisplayDataSource.py
+++ b/pyV2DL3/eventdisplay/EventDisplayDataSource.py
@@ -50,7 +50,11 @@ class EventDisplayDataSource(VtsDataSource):
             )
         )
         logging.info(
-            ("Wobble: offset={0:.2f} deg".format(self.__offset__))
+            (
+                "Wobble direction of the run: ({0:.2f}N, {1:.2f}W) deg "
+            ).format(
+                self.__offset__[0], self.__offset__[1]
+            )
         )
 
         self.__response__ = __fillRESPONSE__(

--- a/pyV2DL3/eventdisplay/EventDisplayDataSource.py
+++ b/pyV2DL3/eventdisplay/EventDisplayDataSource.py
@@ -15,7 +15,6 @@ class EventDisplayDataSource(VtsDataSource):
         self.__azimuth__ = 0
         self.__zenith__ = 0
         self.__pedvar__ = 0
-        self.__offset__ = 0
 
     def __fill_evt__(self, **kwargs):
         try:

--- a/pyV2DL3/eventdisplay/EventDisplayDataSource.py
+++ b/pyV2DL3/eventdisplay/EventDisplayDataSource.py
@@ -33,6 +33,7 @@ class EventDisplayDataSource(VtsDataSource):
         self.__azimuth__ = ea_config["azimuth"]
         self.__zenith__ = ea_config["zenith"]
         self.__pedvar__ = ea_config["pedvar"]
+        self.__offset__ = ea_config["woffset"]
 
     def __fill_gti__(self, **kwargs):
         pass
@@ -43,12 +44,15 @@ class EventDisplayDataSource(VtsDataSource):
                 "Parameters used to query IRFs:"
                 " az={0:.2f} deg,"
                 " ze={1:.2f} deg,"
-                " pedvar={2:.1f},"
-                " offset={3:.2f} deg"
+                " pedvar={2:.1f}"
             ).format(
-                self.__azimuth__, self.__zenith__, self.__pedvar__, self.__offset__
+                self.__azimuth__, self.__zenith__, self.__pedvar__,
             )
         )
+        logging.info(
+            ("Wobble: offset={0:.2f} deg".format(self.__offset__))
+        )
+
         self.__response__ = __fillRESPONSE__(
             self.__evt_file__,
             self.__ea_file__,

--- a/pyV2DL3/eventdisplay/EventDisplayDataSource.py
+++ b/pyV2DL3/eventdisplay/EventDisplayDataSource.py
@@ -33,7 +33,6 @@ class EventDisplayDataSource(VtsDataSource):
         self.__azimuth__ = ea_config["azimuth"]
         self.__zenith__ = ea_config["zenith"]
         self.__pedvar__ = ea_config["pedvar"]
-        self.__offset__ = ea_config["woffset"]
 
     def __fill_gti__(self, **kwargs):
         pass
@@ -49,13 +48,6 @@ class EventDisplayDataSource(VtsDataSource):
                 self.__azimuth__, self.__zenith__, self.__pedvar__,
             )
         )
-        logging.info(
-            (
-                "Wobble direction of the run: ({0:.2f}N, {1:.2f}W) deg "
-            ).format(
-                self.__offset__[0], self.__offset__[1]
-            )
-        )
 
         self.__response__ = __fillRESPONSE__(
             self.__evt_file__,
@@ -63,6 +55,5 @@ class EventDisplayDataSource(VtsDataSource):
             self.__azimuth__,
             self.__zenith__,
             self.__pedvar__,
-            self.__offset__,
             self.__irf_to_store__,
         )

--- a/pyV2DL3/eventdisplay/fillEVENTS.py
+++ b/pyV2DL3/eventdisplay/fillEVENTS.py
@@ -170,12 +170,8 @@ def __fillEVENTS__(edFileIO, select=None):
 
         wobble = np.array([
             runSummary["WobbleNorth"][0],
-            runSummary["WobbleNorth"][1],
             runSummary["WobbleWest"][0],
-            runSummary["WobbleWest"][1],
         ])
-        print(np.sort(wobble))
-        Woffset = np.sort(wobble)[-1]
 
         try:
             BitArray = file["run_{}".format(runNumber)]["stereo"]["timeMask"][
@@ -201,6 +197,6 @@ def __fillEVENTS__(edFileIO, select=None):
             "TSTART": tstart_from_reference,
             "TSTOP": tstop_from_reference,
         },
-        {"azimuth": avAz, "zenith": (90.0 - avAlt), "pedvar": avPedvar, "woffset": Woffset},
+        {"azimuth": avAz, "zenith": (90.0 - avAlt), "pedvar": avPedvar, "woffset": wobble},
         evt_dict,
     )

--- a/pyV2DL3/eventdisplay/fillEVENTS.py
+++ b/pyV2DL3/eventdisplay/fillEVENTS.py
@@ -168,10 +168,6 @@ def __fillEVENTS__(edFileIO, select=None):
 
         avPedvar = runSummary["pedvarsOn"][0]
 
-        wobble = np.array([
-            runSummary["WobbleNorth"][0],
-            runSummary["WobbleWest"][0],
-        ])
 
         try:
             BitArray = file["run_{}".format(runNumber)]["stereo"]["timeMask"][
@@ -197,6 +193,6 @@ def __fillEVENTS__(edFileIO, select=None):
             "TSTART": tstart_from_reference,
             "TSTOP": tstop_from_reference,
         },
-        {"azimuth": avAz, "zenith": (90.0 - avAlt), "pedvar": avPedvar, "woffset": wobble},
+        {"azimuth": avAz, "zenith": (90.0 - avAlt), "pedvar": avPedvar},
         evt_dict,
     )

--- a/pyV2DL3/eventdisplay/fillEVENTS.py
+++ b/pyV2DL3/eventdisplay/fillEVENTS.py
@@ -168,6 +168,15 @@ def __fillEVENTS__(edFileIO, select=None):
 
         avPedvar = runSummary["pedvarsOn"][0]
 
+        wobble = np.array([
+            runSummary["WobbleNorth"][0],
+            runSummary["WobbleNorth"][1],
+            runSummary["WobbleWest"][0],
+            runSummary["WobbleWest"][1],
+        ])
+        print(np.sort(wobble))
+        Woffset = np.sort(wobble)[-1]
+
         try:
             BitArray = file["run_{}".format(runNumber)]["stereo"]["timeMask"][
                 "maskBits"
@@ -192,6 +201,6 @@ def __fillEVENTS__(edFileIO, select=None):
             "TSTART": tstart_from_reference,
             "TSTOP": tstop_from_reference,
         },
-        {"azimuth": avAz, "zenith": (90.0 - avAlt), "pedvar": avPedvar},
+        {"azimuth": avAz, "zenith": (90.0 - avAlt), "pedvar": avPedvar, "woffset": Woffset},
         evt_dict,
     )

--- a/pyV2DL3/eventdisplay/fillEVENTS.py
+++ b/pyV2DL3/eventdisplay/fillEVENTS.py
@@ -168,7 +168,6 @@ def __fillEVENTS__(edFileIO, select=None):
 
         avPedvar = runSummary["pedvarsOn"][0]
 
-
         try:
             BitArray = file["run_{}".format(runNumber)]["stereo"]["timeMask"][
                 "maskBits"

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -78,7 +78,6 @@ def fill_effective_area(
     camera_offsets,
     pedvar,
     zenith,
-    offset,
     theta_low,
     theta_high,
 ):
@@ -116,7 +115,6 @@ def fill_energy_migration(
     camera_offsets,
     pedvar,
     zenith,
-    offset,
     theta_low,
     theta_high,
 ):
@@ -158,7 +156,7 @@ def fill_energy_migration(
 
 
 def fill_direction_migration(
-    irf_interpolator, camera_offsets, pedvar, zenith, offset, theta_low, theta_high
+    irf_interpolator, camera_offsets, pedvar, zenith, theta_low, theta_high
 ):
     """Direction dispersion (for full-enclosure IRFs)"""
 
@@ -206,7 +204,7 @@ def fill_direction_migration(
 
 
 def __fillRESPONSE__(
-    edFileIO, effectiveArea, azimuth, zenith, pedvar, offset, irf_to_store=None
+    edFileIO, effectiveArea, azimuth, zenith, pedvar, irf_to_store=None
 ):
     if irf_to_store is None:
         irf_to_store = {}
@@ -247,7 +245,6 @@ def __fillRESPONSE__(
             camera_offsets,
             pedvar,
             zenith,
-            offset,
             theta_low,
             theta_high,
         )
@@ -265,7 +262,6 @@ def __fillRESPONSE__(
             camera_offsets,
             pedvar,
             zenith,
-            offset,
             theta_low,
             theta_high,
         )
@@ -291,7 +287,6 @@ def __fillRESPONSE__(
             camera_offsets,
             pedvar,
             zenith,
-            offset,
             theta_low,
             theta_high,
         )
@@ -303,7 +298,6 @@ def __fillRESPONSE__(
             camera_offsets,
             pedvar,
             zenith,
-            offset,
             theta_low,
             theta_high,
         )
@@ -314,7 +308,6 @@ def __fillRESPONSE__(
             camera_offsets,
             pedvar,
             zenith,
-            offset,
             theta_low,
             theta_high,
         )


### PR DESCRIPTION
wobble offset value was not stored for logging in EventDisplayDataSource.py [here](https://github.com/VERITAS-Observatory/V2DL3/blob/1181214225f03c2d701ad30b0ef54a700e360e90/pyV2DL3/eventdisplay/EventDisplayDataSource.py#L49). This PR reads wobble offset from anasum runSummary and writes out for logging.