### PR TITLE
Use consistently fEffAreaH2F as IRF tree

### DIFF
--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -315,7 +315,7 @@ def __fill_response__(
     irf_interpolator = IrfInterpolator(effective_area, azimuth)
 
     # Extract camera offsets available from the effective areas file.
-    fast_eff_area = uproot.open(effective_area)["fEffArea"]
+    fast_eff_area = uproot.open(effective_area)["fEffAreaH2F"]
     camera_offsets = np.unique(
         np.round(fast_eff_area["Woff"].array(library="np"), decimals=2)
     )


### PR DESCRIPTION
This is a minor modification to use consistently the IRF tree fEffAreaH2F and not in this single place fEffArea.

This should have no impact on any results, the only difference should be a small performance improvement (as fEffAreaH2F has a factor of 20 less entries than fEffArea).

@sona-patel - would still be good to test this for an epoch where you see larger differences between eventdisplay and gammapy analysis.