### PR TITLE
v2dl3-vegas: Event Selection Patch

### DIFF
--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -6,10 +6,13 @@ from pyV2DL3.addHDUClassKeyword import addHDUClassKeyword
 import pyV2DL3.constant as constant
 
 
-def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None):
+def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None, event_class_idx=None):
 
     logging.debug("Create EVENT HDU")
     evt_dict = datasource.get_evt_data()
+
+    if event_class_idx is not None:
+        evt_dict = evt_dict[event_class_idx]
 
     # Columns to be saved
     columns = [
@@ -19,6 +22,14 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None):
         fits.Column(name="DEC", format="1E", array=evt_dict["DEC"], unit="deg"),
         fits.Column(name="ENERGY", format="1E", array=evt_dict["ENERGY"], unit="TeV"),
     ]
+    if "MSW" in evt_dict:
+        columns.append(
+            fits.Column(name='MSW', format='1D', array=evt_dict['MSW'])
+        )
+    if "MSL" in evt_dict:
+        columns.append(
+            fits.Column(name='MSL', format='1D', array=evt_dict['MSL'])
+        )
     try:
         columns.append(fits.Column("IS_GAMMA", format="1L", array=evt_dict["IS_GAMMA"]))
         columns.append(
@@ -32,6 +43,10 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None):
         columns.append(
             fits.Column(name="EVENT_TYPE", format="1J", array=evt_dict["EVENT_TYPE"])
         )
+    if "EVENT_CLASS" in evt_dict:
+            columns.append(
+                fits.Column(name="EVENT_CLASS", format="32X", array=evt_dict['EVENT_CLASS'])
+            )
 
     # Create HDU
     hdu1 = fits.BinTableHDU.from_columns(columns)
@@ -118,7 +133,8 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None):
         constant.VTS_REFERENCE_HEIGHT,
         "altitude of array center [m]",
     )
-
+    if event_class_idx is not None:
+        hdu1.header.set("EV_CLASS", event_class_idx, "Event class number")
     try:
         hdu1.header.set(
             "QUALITY",

--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -55,7 +55,7 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None, event
     add_existing_column(columns, evt_dict, name="MSL", format="1D")
     add_existing_column(columns, evt_dict, name="IS_GAMMA", format="1L")
     add_existing_column(columns, evt_dict, name="BDT_SCORE", format="1E")
-    
+
     # Number of triggered telescope if necessary
     if save_multiplicity:
         columns.append(

--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -43,10 +43,6 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None, event
         columns.append(
             fits.Column(name="EVENT_TYPE", format="1J", array=evt_dict["EVENT_TYPE"])
         )
-    if "EVENT_CLASS" in evt_dict:
-            columns.append(
-                fits.Column(name="EVENT_CLASS", format="32X", array=evt_dict['EVENT_CLASS'])
-            )
 
     # Create HDU
     hdu1 = fits.BinTableHDU.from_columns(columns)

--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -12,6 +12,7 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None, event
     evt_dict = datasource.get_evt_data()
 
     if event_class_idx is not None:
+        add_evclass = True if len(evt_dict) > 1 else False
         evt_dict = evt_dict[event_class_idx]
 
     # Columns to be saved
@@ -129,7 +130,7 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None, event
         constant.VTS_REFERENCE_HEIGHT,
         "altitude of array center [m]",
     )
-    if event_class_idx is not None:
+    if event_class_idx is not None and add_evclass:
         hdu1.header.set("EV_CLASS", event_class_idx, "Event class number")
     try:
         hdu1.header.set(

--- a/pyV2DL3/fillRESPONSE.py
+++ b/pyV2DL3/fillRESPONSE.py
@@ -67,9 +67,13 @@ def fill_bintablehdu(
     return hdu
 
 
-def fillRESPONSE(datasource, instrument_epoch=None):
+def fillRESPONSE(datasource, instrument_epoch=None, event_class_idx=None):
     response_dict = datasource.get_response_data()
     evt_dict = datasource.get_evt_data()
+
+    if event_class_idx is not None:
+        response_dict = response_dict[event_class_idx]
+        evt_dict = evt_dict[event_class_idx]
 
     epoch_str = "VERITAS"
     if instrument_epoch:

--- a/pyV2DL3/genHDUList.py
+++ b/pyV2DL3/genHDUList.py
@@ -50,15 +50,16 @@ def loadROOTFiles(data_file, effective_area_file, file_type="VEGAS",
         return EventDisplayDataSource(data_file, effective_area_file)
 
 
-def genHDUlist(datasource, save_multiplicity=False, instrument_epoch=None):
+def genHDUlist(datasource, save_multiplicity=False, instrument_epoch=None, event_class_idx=None):
     hdus = [
         genPrimaryHDU(),
         fillEVENTS(
             datasource,
             save_multiplicity=save_multiplicity,
             instrument_epoch=instrument_epoch,
+            event_class_idx=event_class_idx,
         ),
         fillGTI(datasource),
     ]
-    hdus.extend(fillRESPONSE(datasource, instrument_epoch))
+    hdus.extend(fillRESPONSE(datasource, instrument_epoch, event_class_idx=event_class_idx))
     return fits.HDUList(hdus)

--- a/pyV2DL3/genHDUList.py
+++ b/pyV2DL3/genHDUList.py
@@ -28,6 +28,7 @@ def genPrimaryHDU():
 
 def loadROOTFiles(data_file, effective_area_file, file_type="VEGAS",
                   event_classes=None,
+                  save_msw_msl=False,
                   ):
 
     if effective_area_file is None and event_classes is None:
@@ -37,6 +38,7 @@ def loadROOTFiles(data_file, effective_area_file, file_type="VEGAS",
         from pyV2DL3.vegas.VegasDataSource import VegasDataSource
         return VegasDataSource(data_file, effective_area_file,
                                event_classes=event_classes,
+                               save_msw_msl=save_msw_msl,
                                )
 
     if file_type != "ED":

--- a/pyV2DL3/script/v2dl3_for_vegas.py
+++ b/pyV2DL3/script/v2dl3_for_vegas.py
@@ -170,7 +170,7 @@ def cli(
             hdulist[1].header["OBS_ID"] = fname_base
         hdulist.writeto(output, overwrite=True)
     # Runlist mode
-    else:        
+    else:   
         from pyV2DL3.vegas.parseSt6RunList import parseRunlistStrs
         from pyV2DL3.vegas.parseSt6RunList import RunlistParsingError
         from pyV2DL3.vegas.parseSt6RunList import RunlistValidationError
@@ -253,11 +253,13 @@ Arguments:
     output        --  Destination to write the generated index files.
     eclass_count  --  Number of event classes for this run
 """
+
+
 def gen_index_files(flist, output, eclass_count=1):
     # Generate master index files
     logging.info(
-                f"Generating index files {output}/obs-index.fits.gz "
-                f"and {output}/hdu-index.fits.gz"
+        f"Generating index files {output}/obs-index.fits.gz "
+        f"and {output}/hdu-index.fits.gz"
     )
     create_obs_hdu_index_file(flist, output)
 
@@ -276,7 +278,7 @@ def gen_index_files(flist, output, eclass_count=1):
 
 
 """
-Sorts output files to subdirectories and appends "_ec#" to their filename 
+Sorts output files to subdirectories and appends "_ec#" to their filename
 according to event class.
 
 Arguments:
@@ -284,6 +286,8 @@ Arguments:
     output       --  Base output directory
     eclass_idx   --  The event class # that this file belongs to.
 """
+
+
 def make_eclass_path(fname_base, output, eclass_idx):
     output_path = f"{output}/ec" + str(eclass_idx)
     if not os.path.exists(output_path):
@@ -295,7 +299,7 @@ def make_eclass_path(fname_base, output, eclass_idx):
     # If no '.' found, append to end
     else:
         eclass_fname = fname_base + "_ec" + str(eclass_idx)
-    
+
     return output_path + "/" + eclass_fname
 
 

--- a/pyV2DL3/script/v2dl3_for_vegas.py
+++ b/pyV2DL3/script/v2dl3_for_vegas.py
@@ -221,7 +221,7 @@ def cli(
                 datasource.fill_data()
 
             # Prepare output paths
-            output_path = f"{output}/{fname_base}"
+            output_path = os.path.join(output, fname_base)
             # This is length 1 when not using event class mode
             num_event_groups = len(datasource.get_evt_data())
             if num_event_groups < 1:
@@ -229,7 +229,7 @@ def cli(
             for i in range(0, num_event_groups):
                 # Make event class subdirectories if there is more than one event group in the VegasDataSource
                 if num_event_groups > 1:
-                    output_path = make_eclass_path(fname_base, output, i)
+                    output_path = make_eclass_path(output, fname_base, i)
 
                 # Write out the fits files
                 hdulist = genHDUlist(datasource, save_multiplicity=save_multiplicity, event_class_idx=i)
@@ -268,14 +268,14 @@ def gen_index_files(flist, output, eclass_count=1):
     if eclass_count > 1:
         for i in range(0, eclass_count):
             eclass_flist = []
-            eclass_output = f"{output}/ec" + str(i)
-            for fname in os.listdir(eclass_output):
-                eclass_flist.append(eclass_output + "/" + fname)
+            eclass_output_dir = os.path.join(output, "ec" + str(i))
+            for fname in os.listdir(eclass_output_dir):
+                eclass_flist.append(os.path.join(eclass_output_dir, fname))
             logging.info(
-                f"Generating index files {eclass_output}/obs-index.fits.gz "
-                f"and {eclass_output}/hdu-index.fits.gz"
+                f"Generating index files {eclass_output_dir}/obs-index.fits.gz "
+                f"and {eclass_output_dir}/hdu-index.fits.gz"
             )
-            create_obs_hdu_index_file(eclass_flist, eclass_output)
+            create_obs_hdu_index_file(eclass_flist, eclass_output_dir)
 
 
 """
@@ -283,14 +283,17 @@ Sorts output files to subdirectories and appends "_ec#" to their filename
 according to event class.
 
 Arguments:
-    fname_base   --  Filename of the fits file
-    output       --  Base output directory
-    eclass_idx   --  The event class # that this file belongs to.
+    output       --  Output directory
+    fname_base   --  Name of the fits file (without '.fits')
+    eclass_idx   --  The event class # that this file belongs to
+
+Returns:
+    New output path (excluding '.fits') as a string
 """
 
 
-def make_eclass_path(fname_base, output, eclass_idx):
-    output_path = f"{output}/ec" + str(eclass_idx)
+def make_eclass_path(output, fname_base, eclass_idx):
+    output_path = os.path.join(output, "ec" + str(eclass_idx))
     if not os.path.exists(output_path):
         os.makedirs(output_path)
     stage_idx = fname_base.find(".")
@@ -301,7 +304,7 @@ def make_eclass_path(fname_base, output, eclass_idx):
     else:
         eclass_fname = fname_base + "_ec" + str(eclass_idx)
 
-    return output_path + "/" + eclass_fname
+    return os.path.join(output_path, eclass_fname)
 
 
 if __name__ == "__main__":

--- a/pyV2DL3/script/v2dl3_for_vegas.py
+++ b/pyV2DL3/script/v2dl3_for_vegas.py
@@ -223,11 +223,12 @@ def cli(
             # Prepare output paths
             output_path = f"{output}/{fname_base}"
             # This is length 1 when not using event class mode
-            eclass_count = len(datasource.get_evt_data())
-            if eclass_count < 1:
+            num_event_groups = len(datasource.get_evt_data())
+            if num_event_groups < 1:
                 raise Exception("No event data found")
-            for i in range(0, eclass_count):
-                if eclass_count > 1:
+            for i in range(0, num_event_groups):
+                # Make event class subdirectories if there is more than one event group in the VegasDataSource
+                if num_event_groups > 1:
                     output_path = make_eclass_path(fname_base, output, i)
 
                 # Write out the fits files
@@ -242,7 +243,7 @@ def cli(
                 flist.append(output_path)
 
         if gen_index_file:
-            gen_index_files(flist, output, eclass_count=eclass_count)
+            gen_index_files(flist, output, eclass_count=num_event_groups)
 
 
 """

--- a/pyV2DL3/script/v2dl3_for_vegas.py
+++ b/pyV2DL3/script/v2dl3_for_vegas.py
@@ -239,7 +239,7 @@ def cli(
                     # If no '.' found, append to end
                     else:
                         eclass_fname = fname_base + "_ec" + str(i)
-                    output_path + "/" + eclass_fname
+                    output_path += "/" + eclass_fname
 
                 # Write out the fits files
                 hdulist = genHDUlist(datasource, save_multiplicity=save_multiplicity, event_class_idx=i)

--- a/pyV2DL3/script/v2dl3_for_vegas.py
+++ b/pyV2DL3/script/v2dl3_for_vegas.py
@@ -270,7 +270,7 @@ def cli(
                         f"Generating index files {eclass_output}/obs-index.fits.gz "
                         f"and {eclass_output}/hdu-index.fits.gz"
                     )
-                    create_obs_hdu_index_file(eclass_flist, eclass_output, psf_king=irfs_to_store["psf-king"])
+                    create_obs_hdu_index_file(eclass_flist, eclass_output)
 
 if __name__ == "__main__":
     cli()

--- a/pyV2DL3/script/v2dl3_for_vegas.py
+++ b/pyV2DL3/script/v2dl3_for_vegas.py
@@ -170,7 +170,7 @@ def cli(
             hdulist[1].header["OBS_ID"] = fname_base
         hdulist.writeto(output, overwrite=True)
     # Runlist mode
-    else:   
+    else:
         from pyV2DL3.vegas.parseSt6RunList import parseRunlistStrs
         from pyV2DL3.vegas.parseSt6RunList import RunlistParsingError
         from pyV2DL3.vegas.parseSt6RunList import RunlistValidationError

--- a/pyV2DL3/vegas/VegasDataSource.py
+++ b/pyV2DL3/vegas/VegasDataSource.py
@@ -80,7 +80,7 @@ class VegasDataSource(VtsDataSource):
                 )
         # When not using event class mode
         else:
-            response_dicts.append( 
+            response_dicts.append(
                 __fillRESPONSE_not_safe__(self.__ea_file__, az, ze, nn, self.__irf_to_store__)
             )
         self.__response__ = response_dicts

--- a/pyV2DL3/vegas/fillEVENTS_not_safe.py
+++ b/pyV2DL3/vegas/fillEVENTS_not_safe.py
@@ -149,7 +149,7 @@ def __fillEVENTS_not_safe__(vegasFileIO, event_classes=None, save_msw_msl=False)
 
     goodTimeStart, goodTimeStop = getGTArray(startTime_s, endTime_s, mergeTimeCut(tc))
     real_live_time = np.sum(np.array(goodTimeStop) - np.array(goodTimeStart))
-    
+
     # Construct an array to hold the event dict(s) to be returned:
     returned_dicts = []
     for i in range(num_event_classes):

--- a/pyV2DL3/vegas/fillEVENTS_not_safe.py
+++ b/pyV2DL3/vegas/fillEVENTS_not_safe.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 
 from astropy.time import Time
 import numpy as np
@@ -15,9 +16,7 @@ logger = logging.getLogger(__name__)
 windowSizeForNoise = 7
 
 
-def __fillEVENTS_not_safe__(vegasFileIO):
-    evt_dict = {}
-
+def __fillEVENTS_not_safe__(vegasFileIO, event_classes=None, save_msw_msl=False):
     # Load header ,array info and selected event tree ( vegas > v2.5.7)
     runHeader = vegasFileIO.loadTheRunHeader()
     selectedEventsTree = vegasFileIO.loadTheCutEventTree()
@@ -39,35 +38,98 @@ def __fillEVENTS_not_safe__(vegasFileIO):
     startTime_s = startTime_s + seconds_from_reference_t0
     endTime_s = endTime_s + seconds_from_reference_t0
 
-    # Start filling events
+    if event_classes is None:
+        # We use a single "event class" when not in event class mode
+        num_event_classes = 1
+    else:
+        # Set num_event_classes so we dont call len(event_classes)
+        # thousands of times when filling events.
+        num_event_classes = len(event_classes)
+        if num_event_classes < 1:
+            # Dev exception
+            raise Exception("event_classes was passed in as an empty List")
+
+    # These arrays are the same for every event class
     avAlt = []
     avAz = []
     avRA = []
     avDec = []
 
-    evNumArr = []
-    timeArr = []
-    raArr = []
-    decArr = []
-    azArr = []
-    altArr = []
-    energyArr = []
-    nTelArr = []
+    # These arrays are unique to each event class
+    event_arrays = {
+        "evNumArr": [],
+        "timeArr": [],
+        "raArr": [],
+        "decArr": [],
+        "azArr": [],
+        "altArr": [],
+        "energyArr": [],
+        "nTelArr": [],
+    }
+
+    # Arrays exclusive to event class mode
+    if event_classes is not None or save_msw_msl:
+        event_arrays["mswArr"] = []
+        event_arrays["mslArr"] = []
+        if event_classes is not None:
+            event_arrays["eClassArr"] = []
+
+    # Deep copy the dictionary for each event class
+    event_class_dicts = [event_arrays]
+    for i in range(num_event_classes - 1):
+        event_class_dicts.append(deepcopy(event_arrays))
+
     logger.debug("Start filling events ...")
 
     for ev in selectedEventsTree:
+        # When not using event class mode, this will stay 0
+        event_class_idx = 0
+
+        if event_classes is not None:
+            fMSW = ev.S.fMSW
+            """Determine which event class (if any) the event falls into.
+
+            Simply loop through the event classes and break if this event meets all
+            of an event class' parameters
+
+            For now, we only do it based on the MSW intervals
+            """
+            event_class_idx = 0
+            # Loop through event classes to check if this event satisfies the parameters
+            for ec in event_classes:
+                if ec.msw_lower <= fMSW < ec.msw_upper:
+                    break
+                event_class_idx += 1
+
+            # If this event falls into an event classes
+            if event_class_idx < num_event_classes:
+                event_class_dicts[event_class_idx]["eClassArr"].append(
+                    8 * 2**event_class_idx)
+                event_class_dicts[event_class_idx]["mswArr"].append(fMSW)
+                event_class_dicts[event_class_idx]["mslArr"].append(ev.S.fMSL)
+            # Else skip to next event
+            else:
+                logger.debug("Event excluded: " + str(ev.S.fArrayEventNum)
+                             + " MSW: " + str(fMSW))
+                continue
+
+        elif save_msw_msl:
+            event_class_dicts[event_class_idx]["mswArr"].append(fMSW)
+            event_class_dicts[event_class_idx]["mslArr"].append(ev.S.fMSL)
+
         # seconds since first light
         time_relative_to_reference = (
             float(ev.S.fTime.getDayNS()) / 1e9 + seconds_from_reference_t0
         )
-        evNumArr.append(ev.S.fArrayEventNum)
-        timeArr.append(time_relative_to_reference)
-        raArr.append(np.rad2deg(ev.S.fDirectionRA_J2000_Rad))
-        decArr.append(np.rad2deg(ev.S.fDirectionDec_J2000_Rad))
-        azArr.append(np.rad2deg(ev.S.fDirectionAzimuth_Rad))
-        altArr.append(np.rad2deg(ev.S.fDirectionElevation_Rad))
-        energyArr.append(ev.S.fEnergy_GeV / 1000.0)
-        nTelArr.append(ev.S.fImages)
+        this_event_class = event_class_dicts[event_class_idx]
+        this_event_class["evNumArr"].append(ev.S.fArrayEventNum)
+        this_event_class["timeArr"].append(time_relative_to_reference)
+        this_event_class["raArr"].append(np.rad2deg(ev.S.fDirectionRA_J2000_Rad))
+        this_event_class["decArr"].append(np.rad2deg(ev.S.fDirectionDec_J2000_Rad))
+        this_event_class["azArr"].append(np.rad2deg(ev.S.fDirectionAzimuth_Rad))
+        this_event_class["altArr"].append(np.rad2deg(ev.S.fDirectionElevation_Rad))
+        this_event_class["energyArr"].append(ev.S.fEnergy_GeV / 1000.0)
+        this_event_class["nTelArr"].append(ev.S.fImages)
 
         avAlt.append(ev.S.fArrayTrackingElevation_Deg)
         avAz.append(ev.S.fArrayTrackingAzimuth_Deg)
@@ -83,15 +145,6 @@ def __fillEVENTS_not_safe__(vegasFileIO):
 
     avRA = np.rad2deg(np.mean(avRA))
     avDec = np.rad2deg(np.mean(avDec))
-    # Filling Event List
-    evt_dict["EVENT_ID"] = evNumArr
-    evt_dict["TIME"] = timeArr
-    evt_dict["RA"] = raArr
-    evt_dict["DEC"] = decArr
-    evt_dict["ALT"] = altArr
-    evt_dict["AZ"] = azArr
-    evt_dict["ENERGY"] = energyArr
-    evt_dict["EVENT_TYPE"] = nTelArr
 
     # Get Time Cuts and build GTI start and stop time array
     # and calculate live time
@@ -100,29 +153,53 @@ def __fillEVENTS_not_safe__(vegasFileIO):
 
     goodTimeStart, goodTimeStop = getGTArray(startTime_s, endTime_s, mergeTimeCut(tc))
     real_live_time = np.sum(np.array(goodTimeStop) - np.array(goodTimeStart))
+    
+    # Construct an array to hold the event dict(s) to be returned:
+    returned_dicts = []
+    for i in range(num_event_classes):
+        returned_dicts.append({})
 
-    # Filling Header info
-    evt_dict["OBS_ID"] = runHeader.getRunNumber()
-    evt_dict["DATE-OBS"] = startTime.getString().split()[0]
-    evt_dict["TIME-OBS"] = startTime.getString().split()[1]
-    evt_dict["DATE-END"] = endTime.getString().split()[0]
-    evt_dict["TIME-END"] = endTime.getString().split()[1]
-    evt_dict["TSTART"] = startTime_s
-    evt_dict["TSTOP"] = endTime_s
-    evt_dict["ONTIME"] = endTime_s - startTime_s
-    evt_dict["LIVETIME"] = (
-        runHeader.getLiveTimeFrac(True) * real_live_time
-    )  # True to suppress error warnings
-    evt_dict["DEADC"] = evt_dict["LIVETIME"] / evt_dict["ONTIME"]
-    evt_dict["OBJECT"] = runHeader.getSourceId()
-    evt_dict["RA_PNT"] = avRA
-    evt_dict["DEC_PNT"] = avDec
-    evt_dict["ALT_PNT"] = avAlt
-    evt_dict["AZ_PNT"] = avAz
-    evt_dict["RA_OBJ"] = np.rad2deg(runHeader.getSourceRA())
-    evt_dict["DEC_OBJ"] = np.rad2deg(runHeader.getSourceDec())
-    evt_dict["TELLIST"] = produceTelList(runHeader.fRunInfo.fConfigMask)
-    evt_dict["N_TELS"] = runHeader.pfRunDetails.fTels
+    # Filling Event List(s)
+    for index in range(num_event_classes):
+        # Fill each event class's FITS format from its corresponding event arrays
+        evt_dict = returned_dicts[index]
+        arr_dict = event_class_dicts[index]
+        evt_dict["EVENT_ID"] = arr_dict["evNumArr"]
+        evt_dict["TIME"] = arr_dict["timeArr"]
+        evt_dict["RA"] = arr_dict["raArr"]
+        evt_dict["DEC"] = arr_dict["decArr"]
+        evt_dict["ALT"] = arr_dict["altArr"]
+        evt_dict["AZ"] = arr_dict["azArr"]
+        evt_dict["ENERGY"] = arr_dict["energyArr"]
+        evt_dict["EVENT_TYPE"] = arr_dict["nTelArr"]
+        if "mswArr" in arr_dict:
+            evt_dict["MSW"] = arr_dict["mswArr"]
+        if "mslArr" in arr_dict:
+            evt_dict["MSL"] = arr_dict["mslArr"]
+        if "eclassArr" in arr_dict:
+            evt_dict["EVENT_CLASS"] = arr_dict["eClassArr"]
+        # Filling Header info
+        evt_dict["OBS_ID"] = runHeader.getRunNumber()
+        evt_dict["DATE-OBS"] = startTime.getString().split()[0]
+        evt_dict["TIME-OBS"] = startTime.getString().split()[1]
+        evt_dict["DATE-END"] = endTime.getString().split()[0]
+        evt_dict["TIME-END"] = endTime.getString().split()[1]
+        evt_dict["TSTART"] = startTime_s
+        evt_dict["TSTOP"] = endTime_s
+        evt_dict["ONTIME"] = endTime_s - startTime_s
+        evt_dict["LIVETIME"] = (
+            runHeader.getLiveTimeFrac(True) * real_live_time
+        )  # True to suppress error warnings
+        evt_dict["DEADC"] = evt_dict["LIVETIME"] / evt_dict["ONTIME"]
+        evt_dict["OBJECT"] = runHeader.getSourceId()
+        evt_dict["RA_PNT"] = avRA
+        evt_dict["DEC_PNT"] = avDec
+        evt_dict["ALT_PNT"] = avAlt
+        evt_dict["AZ_PNT"] = avAz
+        evt_dict["RA_OBJ"] = np.rad2deg(runHeader.getSourceRA())
+        evt_dict["DEC_OBJ"] = np.rad2deg(runHeader.getSourceDec())
+        evt_dict["TELLIST"] = produceTelList(runHeader.fRunInfo.fConfigMask)
+        evt_dict["N_TELS"] = runHeader.pfRunDetails.fTels
 
     avNoise = 0
     nTels = 0
@@ -141,5 +218,5 @@ def __fillEVENTS_not_safe__(vegasFileIO):
             "TSTOP": endTime_s,
         },
         {"azimuth": avAz, "zenith": (90.0 - avAlt), "noise": avNoise},
-        evt_dict,
+        returned_dicts,
     )

--- a/pyV2DL3/vegas/fillEVENTS_not_safe.py
+++ b/pyV2DL3/vegas/fillEVENTS_not_safe.py
@@ -114,7 +114,7 @@ def __fillEVENTS_not_safe__(vegasFileIO, event_classes=None, save_msw_msl=False)
                 continue
 
         elif save_msw_msl:
-            event_class_dicts[event_class_idx]["mswArr"].append(fMSW)
+            event_class_dicts[event_class_idx]["mswArr"].append(ev.S.fMSW)
             event_class_dicts[event_class_idx]["mslArr"].append(ev.S.fMSL)
 
         # seconds since first light

--- a/pyV2DL3/vegas/fillEVENTS_not_safe.py
+++ b/pyV2DL3/vegas/fillEVENTS_not_safe.py
@@ -71,8 +71,6 @@ def __fillEVENTS_not_safe__(vegasFileIO, event_classes=None, save_msw_msl=False)
     if event_classes is not None or save_msw_msl:
         event_arrays["mswArr"] = []
         event_arrays["mslArr"] = []
-        if event_classes is not None:
-            event_arrays["eClassArr"] = []
 
     # Deep copy the dictionary for each event class
     event_class_dicts = [event_arrays]
@@ -103,8 +101,6 @@ def __fillEVENTS_not_safe__(vegasFileIO, event_classes=None, save_msw_msl=False)
 
             # If this event falls into an event classes
             if event_class_idx < num_event_classes:
-                event_class_dicts[event_class_idx]["eClassArr"].append(
-                    8 * 2**event_class_idx)
                 event_class_dicts[event_class_idx]["mswArr"].append(fMSW)
                 event_class_dicts[event_class_idx]["mslArr"].append(ev.S.fMSL)
             # Else skip to next event
@@ -176,8 +172,6 @@ def __fillEVENTS_not_safe__(vegasFileIO, event_classes=None, save_msw_msl=False)
             evt_dict["MSW"] = arr_dict["mswArr"]
         if "mslArr" in arr_dict:
             evt_dict["MSL"] = arr_dict["mslArr"]
-        if "eclassArr" in arr_dict:
-            evt_dict["EVENT_CLASS"] = arr_dict["eClassArr"]
         # Filling Header info
         evt_dict["OBS_ID"] = runHeader.getRunNumber()
         evt_dict["DATE-OBS"] = startTime.getString().split()[0]


### PR DESCRIPTION
This patch utilizes the previously implemented "EventClass" object in order to select events to separate event lists and FITS files.
New flags have been tested and output has been reproduced with no differences to main using fitsdiff.

Very little VEGAS-specific review here, so I've added a question about how we utilize VEGAS root data in the previous patch.

## For VEGAS Review
 - `fillEVENTS_not_safe.py` accesses additional `selectedEventsTree` attributes `.fMSW` and `.fMSL` in the manner specified by VEGAS docs
 - From previous commit 6c6e3f2: 
    - `EventClass.py` reads EA via VARootIO to get the cuts info ("pfCutsFileText" in the root file)
    - `fCutsFileText` is passed (as a string) to `getCuts()` in `util.py` to search for substrings matching the desired cut param names.
       - This seems to me to be a naive method, but I could not find info about this in the VEGAS docs. I did a fair amount of investigating the EA root files via VARootIO and uproot; it seems to me that cuts info is only available as raw text. However, if there is a VARootIO library method that parses this file for me, that is better to use so it will be paired to VEGAS updates.
       
## Full Changelog
`fillEVENTS.py`
 - Event class support when provided optional arg `event_class_idx`
 - Appends MSW and MSL columns when appropriate
 
 `fillRESPONSE.py`
 - Event class support when provided optional arg `event_class_idx`
 
 `genHDUList.py`
 - Optional arguments added
 
 `v2dl3_for_vegas.py`
 - `-save_msw_msl` flag added
 - Extended fits output for event class mode as new helper function `make_eclass_path()`
 - Extended index file output for event class mode as new helper function `gen_index_files()`
 
 `VegasDataSource.py`
 - Support for event classes and `save_msw_msl` flag
 
 `fillEVENTS_not_safe.py`
 - Now filters events to separate dicts when using >1 event class.
 - Added MSW and MSL access from SelectedEventsTree