### PR TITLE
Generate Index Files Bugfix

### DIFF
--- a/pyV2DL3/generateObsHduIndex.py
+++ b/pyV2DL3/generateObsHduIndex.py
@@ -147,6 +147,7 @@ def gen_obs_index(filelist, index_file_dir="./"):
     )
     _tableunits = {}
     _tabledata = {n: [] for n in names}
+    missing_keys = set()
     # loop through the files
     for _file in filelist:
         # fits files.
@@ -166,11 +167,18 @@ def gen_obs_index(filelist, index_file_dir="./"):
                     value.append(dl3_hdu[1].header[key])
                 except KeyError:
                     logging.warning("Keyword " + key + " not found when building obs. index file")
+                    missing_keys.add(key)
                     continue
 
                 _tableunits[key] = get_unit_string_from_comment(
                     dl3_hdu[1].header.comments[key]
                 )
+
+    for key in missing_keys:
+        key_idx = names.index(key)
+        del names[key_idx]
+        del dtype[key_idx]
+        del _tabledata[key]
 
     obs_table = Table(_tabledata, names=names, dtype=dtype)
 

--- a/pyV2DL3/generateObsHduIndex.py
+++ b/pyV2DL3/generateObsHduIndex.py
@@ -103,7 +103,7 @@ def get_unit_string_from_comment(comment_string):
 
 
 def gen_obs_index(filelist, index_file_dir="./"):
-    names = (
+    names = [
         "OBS_ID",
         "RA_PNT",
         "DEC_PNT",
@@ -123,8 +123,8 @@ def gen_obs_index(filelist, index_file_dir="./"):
         "DATE-OBS",
         "DATE-END",
         "NSBLEVEL",
-    )
-    dtype = (
+    ]
+    dtype = [
         ">i8",
         ">f4",
         ">f4",
@@ -144,7 +144,7 @@ def gen_obs_index(filelist, index_file_dir="./"):
         "S20",
         "S20",
         ">f4",
-    )
+    ]
     _tableunits = {}
     _tabledata = {n: [] for n in names}
     missing_keys = set()

--- a/pyV2DL3/generateObsHduIndex.py
+++ b/pyV2DL3/generateObsHduIndex.py
@@ -162,7 +162,12 @@ def gen_obs_index(filelist, index_file_dir="./"):
                     dl3_hdu[1].header.comments["ALT_PNT"]
                 )
             else:
-                value.append(dl3_hdu[1].header[key])
+                try:
+                    value.append(dl3_hdu[1].header[key])
+                except KeyError:
+                    logging.warning("Keyword " + key + " not found when building obs. index file")
+                    continue
+
                 _tableunits[key] = get_unit_string_from_comment(
                     dl3_hdu[1].header.comments[key]
                 )


### PR DESCRIPTION
Generating index files has been bugged for VEGAS by pull request #150. After testing a couple solutions, I propose this fix to handle keys added to the `names` List which are not present at runtime.