### PR TITLE
V2DL3 for Eventdisplay Docker Image Production

### DIFF
--- a/.github/workflows/v2dl3-eventdisplay-packaging.yml
+++ b/.github/workflows/v2dl3-eventdisplay-packaging.yml
@@ -47,8 +47,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-            # push: ${{ github.event_name != 'pull_request' }}
-          push: ${{ github.event_name != 'release' }}
+          push: ${{ github.event_name != 'pull_request' }}
           file: ./V2DL3/utils/v2dl3-eventdisplay-docker/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-v2dl3-eventdisplay

--- a/.github/workflows/v2dl3-eventdisplay-packaging.yml
+++ b/.github/workflows/v2dl3-eventdisplay-packaging.yml
@@ -1,0 +1,51 @@
+# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+name: V2DL3-Eventdisplay
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    branches: ["main"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-v2dl3-eventdisplay:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          path: ''
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          tags: |
+            type=ref,event=pr,suffix=-v2dl3-eventdisplay
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},suffix=-v2dl3-eventdisplay
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          file: ./V2DL3/utils/v2dl3-eventdisplay-docker/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}-v2dl3-eventdisplay

--- a/.github/workflows/v2dl3-eventdisplay-packaging.yml
+++ b/.github/workflows/v2dl3-eventdisplay-packaging.yml
@@ -7,6 +7,8 @@ on:
       - 'v*'
   pull_request:
     branches: ["main"]
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -45,7 +47,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+            # push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'release' }}
           file: ./V2DL3/utils/v2dl3-eventdisplay-docker/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-v2dl3-eventdisplay

--- a/.github/workflows/v2dl3-eventdisplay-packaging.yml
+++ b/.github/workflows/v2dl3-eventdisplay-packaging.yml
@@ -1,5 +1,5 @@
 # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-name: V2DL3-Eventdisplay
+name: Docker-V2DL3-Eventdisplay
 
 on:
   push:
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          path: ''
+          path: 'V2DL3'
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/pyV2DL3/script/compareFitsFiles.py
+++ b/pyV2DL3/script/compareFitsFiles.py
@@ -26,7 +26,7 @@ def cli(file_pair, diff_file):
 
     file1, file2 = file_pair
 
-    fd = fits.FITSDiff(file1, file2)
+    fd = fits.FITSDiff(file1, file2, rtol=1.e-6)
     fd.report(diff_file, overwrite=True)
 
 

--- a/utils/v2dl3-eventdisplay-docker/Dockerfile
+++ b/utils/v2dl3-eventdisplay-docker/Dockerfile
@@ -25,5 +25,6 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
 
 SHELL ["/bin/bash", "-c"]
 
+RUN mkdir /data/
 RUN source /root/.bashrc && \
     conda init bash

--- a/utils/v2dl3-eventdisplay-docker/Dockerfile
+++ b/utils/v2dl3-eventdisplay-docker/Dockerfile
@@ -1,0 +1,29 @@
+# Dockerfile to build V2DL3 for Eventdisplay
+
+FROM python:3.10-slim
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get install -y --no-install-recommends wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH /conda/bin:$PATH
+ENV PYTHONPATH=$PYTHONPATH:"/V2DL3"
+
+COPY V2DL3 /V2DL3
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /conda && \
+    rm ~/miniconda.sh && \
+    /conda/bin/conda clean -tipsy && \
+    /conda/bin/conda install -c conda-forge mamba && \
+    cd /V2DL3 && \
+    mamba env update -n base --file environment-eventdisplay.yml && \
+    mamba clean --all && conda remove --yes mamba && conda clean --all
+
+SHELL ["/bin/bash", "-c"]
+
+RUN source /root/.bashrc && \
+    conda init bash

--- a/utils/v2dl3-eventdisplay-docker/README.md
+++ b/utils/v2dl3-eventdisplay-docker/README.md
@@ -1,0 +1,22 @@
+# V2DL3 Docker file for Eventdisplay
+
+## Using V2DL3 with the docker image
+
+Docker requires explicit binding of paths into the image. Replace `data_path` in the following command accordingly.
+
+```
+docker run --rm -it -v "<data_path>:/data vts-v2dl3 python /V2DL3/pyV2DL3/script/v2dl3_for_Eventdisplay.py --help
+```
+
+Run the image and provide a bash environment:
+```
+docker run --rm -it -v "<data_path>:/data vts-v2dl3 bash
+```
+
+## Building the Image
+
+Note that this Dockerfile is prepared for a Github Action workflow. V2DL3 source code is expected to be in the current directory.
+
+```
+docker build -t vts-v2dl3 .
+```


### PR DESCRIPTION
Add functionality to generate a Docker image for each release and each merge to main for the V2DL3-Eventdisplay. Docker images are pushed to https://github.com/VERITAS-Observatory/V2DL3/pkgs/container/v2dl3 with the correct metadata and naming.

Usage is described in https://github.com/VERITAS-Observatory/V2DL3/tree/eventdisplay_docker/utils/v2dl3-eventdisplay-docker

Packages are published here: https://github.com/VERITAS-Observatory/V2DL3/pkgs/container/v2dl3

Package area is at this point private, but I've asked our VERITAS github admins to make it public.
