### PR TITLE
Expand offset array when none present.

### DIFF
--- a/pyV2DL3/vegas/EffectiveAreaFile.py
+++ b/pyV2DL3/vegas/EffectiveAreaFile.py
@@ -80,7 +80,8 @@ class EffectiveAreaFile(object):
             logger.info("No offset axis available from file. Use 0.5 deg as default.")
             index_dict["AbsoluteOffset"] = []
             for _ in range(len(index_dict["Index"])):
-                index_dict["AbsoluteOffset"].append(0.5)
+                index_dict["AbsoluteOffset"].append(0)
+                index_dict["AbsoluteOffset"].append(10)
 
         # Validate Completeness
         axis_dict = {}


### PR DESCRIPTION
The offset array read from the IRF requires >1 items when creating the background map. In the case of a single offset table (like wobble of 0.5 degree), add both 0 and 10.0 deg offsets when none are found inside the IRF, since two numbers are necessary. The table repeats for each entry.