### PR TITLE
Remove root numpy  and process multiple run groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Use the [conda package manager](https://docs.conda.io/projects/conda/en/latest/u
 ```
 conda env create -f environment-vegas.yml
 ```
+Sometimes conda fails, so as an alternative, install and use mamba as a direct replacement to the conda call during the installation.
+
+```
+conda install -c conda-forge mamba
+mamba env create -f environment-vegas.yml
+```
+
 The environment ```v2dl3-vegas``` will be created and can be activated with:
 
 ```

--- a/environment-vegas.yml
+++ b/environment-vegas.yml
@@ -15,7 +15,6 @@ dependencies:
   - python>=3.8
   - pyyaml
   - root
-  - root_numpy
   - scipy
   - tqdm
   - uproot

--- a/pyV2DL3/script/v2dl3_for_vegas.py
+++ b/pyV2DL3/script/v2dl3_for_vegas.py
@@ -356,12 +356,13 @@ def runlist_to_file_pairs(runlist, event_class_mode, output):
     eas = rl_dict["EA"]
     st5s = rl_dict["RUNLIST"]
 
+    file_pairs = []
     for runlist_id in st5s.keys():
         if len(eas[runlist_id]) < 1:
             raise Exception("No EA filenames defined for runlist tag: " + runlist_id)
 
         ea_files = [EffectiveAreaFile(ea) for ea in eas[runlist_id]]
-        file_pairs = [(st5_file, ea_files) for st5_file in st5s[runlist_id]]
+        file_pairs.extend([(st5_file, ea_files) for st5_file in st5s[runlist_id]])
 
     return file_pairs
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
         "scipy",
         "tqdm",
         "uproot",
-        "root_numpy",
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
Remove the usage of root_numpy, which is outdated and no longer supported. Complying with #86 and #88. 
Fix the loading of multiple run-groups in the runlist. 
Minor edit to README including instructions for mamba installation alternative (#175).