### PR TITLE
Simplified docker installation for Eventdisplay

### DIFF
--- a/utils/v2dl3-eventdisplay-docker/Dockerfile
+++ b/utils/v2dl3-eventdisplay-docker/Dockerfile
@@ -1,30 +1,17 @@
 # Dockerfile to build V2DL3 for Eventdisplay
+FROM mambaorg/micromamba:latest
 
-FROM python:3.10-slim
-ENV DEBIAN_FRONTEND=noninteractive
+RUN micromamba install -y -n base -c conda-forge git
 
-RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends wget && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN eval "$(micromamba shell hook --shell bash)" && \
+    micromamba activate && \
+    git clone --depth 1 https://github.com/VERITAS-Observatory/V2DL3.git V2DL3/
 
-ENV PATH /conda/bin:$PATH
-ENV PYTHONPATH=$PYTHONPATH:"/V2DL3"
-
-COPY V2DL3 /V2DL3
-
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /conda && \
-    rm ~/miniconda.sh && \
-    /conda/bin/conda clean -tipsy && \
-    /conda/bin/conda install -c conda-forge mamba && \
-    cd /V2DL3 && \
-    mamba env update -n base --file environment-eventdisplay.yml && \
-    mamba clean --all && conda remove --yes mamba && conda clean --all
+RUN cd V2DL3 && \
+    micromamba install -y -n base -f environment-eventdisplay.yml && \
+    micromamba clean --all --yes
+ENV PYTHONPATH=$PYTHONPATH:"V2DL3/"
 
 SHELL ["/bin/bash", "-c"]
 
-RUN mkdir /data/
-RUN source /root/.bashrc && \
-    conda init bash
+RUN mkdir data/

--- a/utils/v2dl3-eventdisplay-docker/README.md
+++ b/utils/v2dl3-eventdisplay-docker/README.md
@@ -2,21 +2,25 @@
 
 ## Using V2DL3 with the docker image
 
-Docker requires explicit binding of paths into the image. Replace `data_path` in the following command accordingly.
+Docker requires explicit binding of paths into the image. Replace `data_path`
+in the following command accordingly.
 
-```
-docker run --rm -it -v "<data_path>:/data vts-v2dl3 python /V2DL3/pyV2DL3/script/v2dl3_for_Eventdisplay.py --help
+```bash
+docker run --rm -it -v "<data_path>":/data vts-v2dl3 \
+    python V2DL3/pyV2DL3/script/v2dl3_for_Eventdisplay.py --help
 ```
 
 Run the image and provide a bash environment:
-```
+
+```bash
 docker run --rm -it -v "<data_path>:/data vts-v2dl3 bash
 ```
 
 ## Building the Image
 
-Note that this Dockerfile is prepared for a Github Action workflow. V2DL3 source code is expected to be in the current directory.
+Note that this Dockerfile is prepared for a Github Action workflow.
+V2DL3 source code is expected to be in the current directory.
 
-```
+```bash
 docker build -t vts-v2dl3 .
 ```


### PR DESCRIPTION
Use of micromamba base image simplifies docker installation for Eventdisplay significantly.