### PR TITLE
Robustness of Eventdisplay preprocessing

### DIFF
--- a/pyV2DL3/eventdisplay/IrfExtractor.py
+++ b/pyV2DL3/eventdisplay/IrfExtractor.py
@@ -57,7 +57,8 @@ def find_closest_az(azimuth, azMins, azMaxs):
     az_centers = np.array((azMaxs[:-1] + azMins[1:]) / 2.0)
     az_centers[az_centers < 0] += 360
     if np.any(az_centers < 0) or np.any(az_centers > 360):
-        raise ValueError("IRF azimuth bins not in the range 0-360")
+        logging.error("IRF azimuth bins not in the range 0-360")
+        raise ValueError
     return find_nearest(az_centers, azimuth)
 
 
@@ -98,8 +99,8 @@ def extract_irf_1d(filename, irf_name, azimuth=None):
                 find_nearest(woffs, all_Woffs[i]),
             ] = irf[i]
         except Exception:
-            logging.exception("Unexpected error:", sys.exc_info()[0])
-            logging.exception("Entry number ", i)
+            logging.error("Unexpected error:", sys.exc_info()[0])
+            logging.error("Entry number ", i)
             raise
 
     axes = {'energies': energies[0], 'pedvars': pedvars, 'zeniths': zds, 'woffs': woffs}
@@ -160,8 +161,8 @@ def extract_irf_2d(filename, irf_name, azimuth=None):
                 find_nearest(woffs, all_Woffs[i]),
             ] = irf
         except Exception:
-            logging.exception("Unexpected error:", sys.exc_info()[0])
-            logging.exception("Entry number ", i)
+            logging.error("Unexpected error:", sys.exc_info()[0])
+            logging.error("Entry number ", i)
             raise
 
     axes = {
@@ -182,7 +183,8 @@ def extract_irf(filename, irf_name, azimuth=None, irf1d=False):
     """
 
     if not azimuth:
-        raise ValueError("Azimuth for IRF extraction not given")
+        logging.error("Azimuth for IRF extraction not given")
+        raise ValueError
 
     irf_fn = extract_irf_1d if irf1d else extract_irf_2d
     return irf_fn(filename, irf_name, azimuth)

--- a/pyV2DL3/eventdisplay/IrfInterpolator.py
+++ b/pyV2DL3/eventdisplay/IrfInterpolator.py
@@ -23,6 +23,7 @@ class IrfInterpolator:
         if os.path.isfile(filename):
             self.filename = filename
         else:
+            logging.error(f"IRF file not found {filename}")
             raise FileNotFoundError
 
     def set_irf(self, irf_name, **kwargs):
@@ -34,7 +35,7 @@ class IrfInterpolator:
             self.irf_name = irf_name
             self.__load_irf(**kwargs)
         else:
-            logging.exception(
+            logging.error(
                 "The irf you entered: {} is either wrong or not implemented.".format(
                     irf_name
                 )
@@ -75,7 +76,8 @@ class IrfInterpolator:
                 logging.debug("zenith axis index: {}".format(zenith_axis))
 
         if zenith_axis is None:
-            raise ValueError("zenith axis not found in irf_axes")
+            logging.error("zenith axis not found in irf_axes")
+            raise ValueError
 
         self.irf_data = np.flip(irf_data, axis=zenith_axis)
         self.irf_axes = list(irf_axes.values())
@@ -100,14 +102,16 @@ class IrfInterpolator:
         # The interpolation is slightly different for 1D or 2D IRFs.
         if self.azimuth == 0:
             if len(coordinate) != 4:
-                raise ValueError(
+                loging.error(
                     "IRF interpolation: for azimuth 0, require 4 coordinates "
                     "(azimuth,  pedvar, zenith, offset)"
                 )
+                raise ValueError
         elif len(coordinate) != 3:
-            raise ValueError(
+            logging.error(
                 "IRF Interpolation: Require 3 coordinates (pedvar, zenith, offset)"
             )
+            raise ValueError
 
         if self.irf_name in self.implemented_irf_names_2d:
             # In this case, the interpolator needs to interpolate over 2 dimensions:
@@ -120,7 +124,7 @@ class IrfInterpolator:
             interpolated_irf = self.interpolator((self.irf_axes[0], *coordinate))
             return interpolated_irf, [self.irf_axes[0]]
         else:
-            logging.exception(
+            logging.error(
                 "The irf you entered: {}" " is not available.".format(self.irf_name)
             )
             raise WrongIrf

--- a/pyV2DL3/eventdisplay/fillEVENTS.py
+++ b/pyV2DL3/eventdisplay/fillEVENTS.py
@@ -12,6 +12,7 @@ from pyV2DL3.constant import VTS_REFERENCE_MJD
 from pyV2DL3.eventdisplay.util import getGTI
 from pyV2DL3.eventdisplay.util import getRunQuality
 from pyV2DL3.eventdisplay.util import produce_tel_list
+from pyV2DL3.eventdisplay.util import ZeroLengthEventList
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,9 @@ def __fillEVENTS__(edFileIO, select=None):
         DL3EventTree = file["run_{}/stereo/DL3EventTree".format(runNumber)].arrays(
             library="np"
         )
+        if len(DL3EventTree["eventNumber"]) == 0:
+            logging.error("Empty event list")
+            raise ZeroLengthEventList
         evNumArr = DL3EventTree["eventNumber"]
 
         # This should already have microsecond resolution if stored with

--- a/pyV2DL3/eventdisplay/fillEVENTS.py
+++ b/pyV2DL3/eventdisplay/fillEVENTS.py
@@ -69,10 +69,11 @@ def __fillEVENTS__(edFileIO, select=None):
         # double precision. Max 24*60*60 seconds
         time_of_day = DL3EventTree["timeOfDay"]
         if time_of_day.max() > 24 * 60 * 60:
-            raise ValueError(
+            logging.error(
                 "Max value in time_of_day  \
                               array exceeds length of a day"
             )
+            raise ValueError
         # mjd time in full days since reference time + event time
         timeArr = seconds_from_reference + time_of_day
 
@@ -87,10 +88,10 @@ def __fillEVENTS__(edFileIO, select=None):
                         & (DL3EventTree[key] <= value[1])
                     )
                 else:
-                    raise TypeError(
-                        "select condition required \
-                                     a list or tuple of ranges"
+                    logging.error(
+                        "select condition required a list or tuple of ranges"
                     )
+                    raise TypeError
             logging.info(f"{np.sum(mask)} of {len(mask)} events after selection.")
 
         raArr = DL3EventTree["RA"][mask]
@@ -181,8 +182,9 @@ def __fillEVENTS__(edFileIO, select=None):
             )
             evt_dict["QUALITY"] = getRunQuality(evndisplog_data)
         except KeyError:
-            logging.exception("Eventdisplay logfile not found in anasum root file")
-            logging.exception("Please make sure to use Eventdisplay >= 486")
+            logging.error("Eventdisplay logfile not found in anasum root file")
+            logging.error("Please make sure to use Eventdisplay >= 486")
+            raise
 
         avPedvar = runSummary["pedvarsOn"][0]
 

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -310,7 +310,8 @@ def fill_direction_migration(
             norm = norm * 2 * np.pi
             direction_diff = direction_diff / (
                 np.repeat(((r_low + r_high) / 2)[..., np.newaxis], len(axis[0]), axis=1) ** 2)
-            normed = direction_diff / norm * ((180 / np.pi) ** 2)
+            with np.errstate(invalid='ignore'):
+                normed = direction_diff / norm * ((180 / np.pi) ** 2)
             rpsf_final.append(np.nan_to_num(normed))
 
     # PSF (3-dim with axes: psf[rad_index, offset_index, energy_index]

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -74,11 +74,11 @@ def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
             elif check_fuzzy_boundary(par, np.min(irf_stored_par), tolerance):
                 par = np.min(irf_stored_par)
             else:
-                raise ValueError("Tolerance not calculated for coordinate {0}".format(par_name))
+                logging.error("Tolerance not calculated for coordinate {0}".format(par_name))
+                raise ValueError
         else:
-            raise ValueError(
-                "Coordinate not inside IRF {0} range! Try using --fuzzy_boundary".format(par_name)
-            )
+            logging.error("Coordinate not inside IRF {0} range! Try using --fuzzy_boundary".format(par_name)
+            raise ValueError
     return par
 
 
@@ -112,11 +112,12 @@ def check_fuzzy_boundary(par, boundary, tolerance):
             )
             return True
         else:
-            raise ValueError(
+            logging.error(
                 "Coordinate tolerance is {0:0.3f} and is outside {1:0.3f}".format(
                     fuzzy_diff, tolerance
                 )
             )
+            raise ValueError
 
     return False
 

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -77,7 +77,7 @@ def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
                 logging.error("Tolerance not calculated for coordinate {0}".format(par_name))
                 raise ValueError
         else:
-            logging.error("Coordinate not inside IRF {0} range! Try using --fuzzy_boundary".format(par_name)
+            logging.error("Coordinate not inside IRF {0} range! Try using --fuzzy_boundary".format(par_name))
             raise ValueError
     return par
 

--- a/pyV2DL3/eventdisplay/util.py
+++ b/pyV2DL3/eventdisplay/util.py
@@ -11,6 +11,10 @@ class WrongIrf(Exception):
         self.errors = errors
 
 
+class ZeroLengthEventList(Exception):
+    pass
+
+
 def produce_tel_list(tel_config):
     """Convert the list of telescopes into a string for FITS header"""
     tel_list = "".join("T" + str(tel) + "," for tel in tel_config["TelType"])


### PR DESCRIPTION
Improve the robustness and error search for processing a large number of files:

- consistently use `logging.error` before raising exceptions
- replace logging.exceptions by logging.errors (as full trace is not needed)
- handle numpy warnings