### PR TITLE
Introduce axis dependent fuzzy boundaries (Eventdisplay converter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The run having their observational parameters (zenith, night sky background) out
 
 - `--force_extrapolation`: This option extrapolates linearly the IRF at the run parameter value. Use this option with a caution since the exptrapolation happens even for run parameter values very far from the corresponding IRF axes range.
 
-- `--fuzzy_boundary tolerance`: This option interpolates the IRF at the boundary value if the run parameter value is within the given tolerance. The tolerance is define as the ratio of absolute difference between boundary and run parameter value to boundary. This option is preferable over `--force_extrapolation`. 
+- `--fuzzy_boundary tolerance`: This option interpolates the IRF at the boundary value if the run parameter value is within the given tolerance. The tolerance is define as the ratio of absolute difference between boundary and run parameter value to boundary. Tolerances are given per IRF axes, with allowed axes are `zenith` and `pedvar` This option is preferable over `--force_extrapolation`. Example: `--fuzzy_boundary pedvar 0.10 --fuzzy_boundary zenith 0.05`.
 
 ---
 # Data storage and generating index files

--- a/pyV2DL3/eventdisplay/IrfInterpolator.py
+++ b/pyV2DL3/eventdisplay/IrfInterpolator.py
@@ -102,7 +102,7 @@ class IrfInterpolator:
         # The interpolation is slightly different for 1D or 2D IRFs.
         if self.azimuth == 0:
             if len(coordinate) != 4:
-                loging.error(
+                logging.error(
                     "IRF interpolation: for azimuth 0, require 4 coordinates "
                     "(azimuth,  pedvar, zenith, offset)"
                 )

--- a/pyV2DL3/eventdisplay/fillEVENTS.py
+++ b/pyV2DL3/eventdisplay/fillEVENTS.py
@@ -186,8 +186,6 @@ def __fillEVENTS__(edFileIO, select=None):
             logging.error("Please make sure to use Eventdisplay >= 486")
             raise
 
-        avPedvar = runSummary["pedvarsOn"][0]
-
         try:
             BitArray = file["run_{}".format(runNumber)]["stereo"]["timeMask"][
                 "maskBits"

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -83,9 +83,9 @@ def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
         if extrapolation:
             logging.warning("IRF extrapolation allowed for coordinate not inside IRF {0} range".format(par_name))
         elif tolerance > 0.0:
-            if check_fuzzy_boundary(par, np.max(irf_stored_par), tolerance, par_name):
+            if check_fuzzy_boundary(par, np.max(irf_stored_par), tolerance, par_name, True):
                 par = np.max(irf_stored_par)
-            elif check_fuzzy_boundary(par, np.min(irf_stored_par), tolerance, par_name):
+            elif check_fuzzy_boundary(par, np.min(irf_stored_par), tolerance, par_name, False):
                 par = np.min(irf_stored_par)
             else:
                 logging.error("Tolerance not calculated for coordinate {0}".format(par_name))
@@ -96,7 +96,7 @@ def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
     return par
 
 
-def check_fuzzy_boundary(par, boundary, tolerance, par_name):
+def check_fuzzy_boundary(par, boundary, tolerance, par_name, max_test=False):
     """" Checks if the parameter value is within the given tolerance.
     tolerance parameter is defined as ratio of absolute difference
     between boundary and par to the boundary.
@@ -107,6 +107,7 @@ def check_fuzzy_boundary(par, boundary, tolerance, par_name):
     boundary: lower or upper boundary value of stored IRF
     tolerance: allowed value of --fuzzy_boundary command line argument
     par_name: parameter name
+    max_test: check for maximum (if True)
 
     Returns
     -------
@@ -118,7 +119,7 @@ def check_fuzzy_boundary(par, boundary, tolerance, par_name):
         return False
 
     if boundary > 0:
-        fuzzy_diff = np.abs(boundary - par) / boundary
+        fuzzy_diff = (par - boundary) / boundary
         if fuzzy_diff < tolerance:
             logging.info(
                 "Coordinate {0} tolerance is {1:0.3f} and is within {2:0.3f}".format(

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -16,12 +16,8 @@ class FullEnclosureOffsetAxisError(Exception):
 
 def find_energy_range(log_energy_tev):
     """Find min and max of energy axis"""
-    energy_low = np.power(
-        10, log_energy_tev - (log_energy_tev[1] - log_energy_tev[0]) / 2.0
-    )
-    energy_high = np.power(
-        10, log_energy_tev + (log_energy_tev[1] - log_energy_tev[0]) / 2.0
-    )
+    energy_low = np.power(10, log_energy_tev - (log_energy_tev[1] - log_energy_tev[0]) / 2.0)
+    energy_high = np.power(10, log_energy_tev + (log_energy_tev[1] - log_energy_tev[0]) / 2.0)
     return energy_low, energy_high
 
 
@@ -42,9 +38,7 @@ def print_logging_info(irf_to_store, camera_offsets, pedvar, zenith):
 
 
 def get_fuzzy_boundary(par_name, tolerance_tuble):
-    """Return fuzzy boundary value for a given IRF axis (par_name)
-
-    """
+    """Return fuzzy boundary value for a given IRF axis (par_name)"""
 
     try:
         for key, value in tolerance_tuble:
@@ -55,14 +49,15 @@ def get_fuzzy_boundary(par_name, tolerance_tuble):
 
     return 0.0
 
+
 def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
     """Check that coordinates are in range of provided IRF and whether extrapolation is to be done
-       0. checks if command line parameter force_extrapolation is given. If given,
-          the extrapolation will happen when parameter is outside IRF range. If parameter is
-          within IRF range, it works as normal. Default is False.
-       1. Further checks for fuzzy boundary (parameter close to boundary value).
-          If fuzzy boundary is within a given tolerance then IRF is interpolated for
-          at boundary value. Default is 0.0 tolerance.
+    0. checks if command line parameter force_extrapolation is given. If given,
+       the extrapolation will happen when parameter is outside IRF range. If parameter is
+       within IRF range, it works as normal. Default is False.
+    1. Further checks for fuzzy boundary (parameter close to boundary value).
+       If fuzzy boundary is within a given tolerance then IRF is interpolated for
+       at boundary value. Default is 0.0 tolerance.
     """
 
     logging.info(
@@ -81,23 +76,31 @@ def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
 
     if np.all(irf_stored_par < par) or np.all(irf_stored_par > par):
         if extrapolation:
-            logging.warning("IRF extrapolation allowed for coordinate not inside IRF {0} range".format(par_name))
+            logging.warning(
+                "IRF extrapolation allowed for coordinate not inside IRF {0} range".format(par_name)
+            )
         elif tolerance > 0.0:
-            if np.all(irf_stored_par < par) and check_fuzzy_boundary(par, np.max(irf_stored_par), tolerance, par_name ):
+            if np.all(irf_stored_par < par) and check_fuzzy_boundary(
+                par, np.max(irf_stored_par), tolerance, par_name
+            ):
                 par = np.max(irf_stored_par)
-            elif  np.all(irf_stored_par > par) and check_fuzzy_boundary(par, np.min(irf_stored_par), tolerance, par_name):
+            elif np.all(irf_stored_par > par) and check_fuzzy_boundary(
+                par, np.min(irf_stored_par), tolerance, par_name
+            ):
                 par = np.min(irf_stored_par)
             else:
                 logging.error("Tolerance not calculated for coordinate {0}".format(par_name))
                 raise ValueError
         else:
-            logging.error("Coordinate not inside IRF {0} range! Try using --fuzzy_boundary".format(par_name))
+            logging.error(
+                "Coordinate not inside IRF {0} range! Try using --fuzzy_boundary".format(par_name)
+            )
             raise ValueError
     return par
 
 
 def check_fuzzy_boundary(par, boundary, tolerance, par_name):
-    """" Checks if the parameter value is within the given tolerance.
+    """ " Checks if the parameter value is within the given tolerance.
     tolerance parameter is defined as ratio of absolute difference
     between boundary and par to the boundary.
 
@@ -174,14 +177,7 @@ def duplicate_interpolating_coordinate(camera_offsets, irf_name):
 
 
 def fill_effective_area(
-        irf_name,
-        irf_interpolator,
-        camera_offsets,
-        pedvar,
-        zenith,
-        theta_low,
-        theta_high,
-        **kwargs
+    irf_name, irf_interpolator, camera_offsets, pedvar, zenith, theta_low, theta_high, **kwargs
 ):
     """Effective areas"""
 
@@ -214,14 +210,7 @@ def fill_effective_area(
 
 
 def fill_energy_migration(
-        irf_name,
-        irf_interpolator,
-        camera_offsets,
-        pedvar,
-        zenith,
-        theta_low,
-        theta_high,
-        **kwargs
+    irf_name, irf_interpolator, camera_offsets, pedvar, zenith, theta_low, theta_high, **kwargs
 ):
     """Energy migration matrix"""
 
@@ -263,7 +252,7 @@ def fill_energy_migration(
 
 
 def fill_direction_migration(
-        irf_interpolator, camera_offsets, pedvar, zenith, theta_low, theta_high, **kwargs
+    irf_interpolator, camera_offsets, pedvar, zenith, theta_low, theta_high, **kwargs
 ):
     """Direction dispersion (for full-enclosure IRFs)"""
 
@@ -274,7 +263,6 @@ def fill_direction_migration(
     test_psf = False  # use PSF distribution from IRFs by default
 
     for offset in camera_offsets:
-
         # direction diff (rad, energy),
         direction_diff, axis = irf_interpolator.interpolate([pedvar, zenith, offset])
 
@@ -320,12 +308,17 @@ def fill_direction_migration(
             rad_width_deg = np.diff(np.power(10, rad_edges))
             # this step makes sure all arrays have the same dimensions, rad_width_deg and the central rad values are
             # repeated by the length of the energy axis.
-            norm = np.sum(direction_diff * np.repeat(rad_width_deg[..., np.newaxis], len(axis[0]), axis=1)
-                          / np.repeat(((r_low + r_high) / 2)[..., np.newaxis], len(axis[0]), axis=1), axis=0)
+            norm = np.sum(
+                direction_diff
+                * np.repeat(rad_width_deg[..., np.newaxis], len(axis[0]), axis=1)
+                / np.repeat(((r_low + r_high) / 2)[..., np.newaxis], len(axis[0]), axis=1),
+                axis=0,
+            )
             norm = norm * 2 * np.pi
             direction_diff = direction_diff / (
-                np.repeat(((r_low + r_high) / 2)[..., np.newaxis], len(axis[0]), axis=1) ** 2)
-            with np.errstate(invalid='ignore'):
+                np.repeat(((r_low + r_high) / 2)[..., np.newaxis], len(axis[0]), axis=1) ** 2
+            )
+            with np.errstate(invalid="ignore"):
                 normed = direction_diff / norm * ((180 / np.pi) ** 2)
             rpsf_final.append(np.nan_to_num(normed))
 
@@ -351,7 +344,7 @@ def fill_direction_migration(
 
 
 def __fill_response__(
-        ed_file_io, effective_area, azimuth, zenith, pedvar, irf_to_store=None, **kwargs
+    ed_file_io, effective_area, azimuth, zenith, pedvar, irf_to_store=None, **kwargs
 ):
     if irf_to_store is None:
         irf_to_store = {}
@@ -363,15 +356,9 @@ def __fill_response__(
 
     # Extract camera offsets available from the effective areas file.
     fast_eff_area = uproot.open(effective_area)["fEffAreaH2F"]
-    camera_offsets = np.unique(
-        np.round(fast_eff_area["Woff"].array(library="np"), decimals=2)
-    )
-    zeniths_irf = np.unique(
-        np.round(fast_eff_area["ze"].array(library="np"), decimals=0)
-    )
-    pedvar_irf = np.unique(
-        np.round(fast_eff_area["pedvar"].array(library="np"), decimals=2)
-    )
+    camera_offsets = np.unique(np.round(fast_eff_area["Woff"].array(library="np"), decimals=2))
+    zeniths_irf = np.unique(np.round(fast_eff_area["ze"].array(library="np"), decimals=0))
+    pedvar_irf = np.unique(np.round(fast_eff_area["pedvar"].array(library="np"), decimals=2))
 
     print_logging_info(irf_to_store, camera_offsets, pedvar, zenith)
 
@@ -380,21 +367,13 @@ def __fill_response__(
     theta_low, theta_high = find_camera_offsets(camera_offsets)
 
     if irf_to_store["point-like"]:
-
         # Effective area (full-enclosure)
         (
             response_dict["EA"],
             response_dict["LO_THRES"],
             response_dict["HI_THRES"],
         ) = fill_effective_area(
-            "eff",
-            irf_interpolator,
-            camera_offsets,
-            pedvar,
-            zenith,
-            theta_low,
-            theta_high,
-            **kwargs
+            "eff", irf_interpolator, camera_offsets, pedvar, zenith, theta_low, theta_high, **kwargs
         )
 
         # Get RAD_MAX; cuts don't depend on energy/wobble
@@ -412,11 +391,10 @@ def __fill_response__(
             zenith,
             theta_low,
             theta_high,
-            **kwargs
+            **kwargs,
         )
 
     elif irf_to_store["full-enclosure"]:
-
         # require multiple offsets for full enclosure
         if len(camera_offsets) <= 1:
             logger.error(
@@ -439,7 +417,7 @@ def __fill_response__(
             zenith,
             theta_low,
             theta_high,
-            **kwargs
+            **kwargs,
         )
 
         # Energy dispersion (full-enclosure)
@@ -451,18 +429,12 @@ def __fill_response__(
             zenith,
             theta_low,
             theta_high,
-            **kwargs
+            **kwargs,
         )
 
         # Direction dispersion (for full-enclosure IRFs)
         response_dict["PSF"] = fill_direction_migration(
-            irf_interpolator,
-            camera_offsets,
-            pedvar,
-            zenith,
-            theta_low,
-            theta_high,
-            **kwargs
+            irf_interpolator, camera_offsets, pedvar, zenith, theta_low, theta_high, **kwargs
         )
 
     return response_dict

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -83,9 +83,9 @@ def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
         if extrapolation:
             logging.warning("IRF extrapolation allowed for coordinate not inside IRF {0} range".format(par_name))
         elif tolerance > 0.0:
-            if check_fuzzy_boundary(par, np.max(irf_stored_par), tolerance, par_name ):
+            if np.all(irf_stored_par < par) and check_fuzzy_boundary(par, np.max(irf_stored_par), tolerance, par_name ):
                 par = np.max(irf_stored_par)
-            elif check_fuzzy_boundary(par, np.min(irf_stored_par), tolerance, par_name):
+            elif  np.all(irf_stored_par > par) and check_fuzzy_boundary(par, np.min(irf_stored_par), tolerance, par_name):
                 par = np.min(irf_stored_par)
             else:
                 logging.error("Tolerance not calculated for coordinate {0}".format(par_name))

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -83,9 +83,9 @@ def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
         if extrapolation:
             logging.warning("IRF extrapolation allowed for coordinate not inside IRF {0} range".format(par_name))
         elif tolerance > 0.0:
-            if check_fuzzy_boundary(par, np.max(irf_stored_par), tolerance, par_name, True):
+            if check_fuzzy_boundary(par, np.max(irf_stored_par), tolerance, par_name ):
                 par = np.max(irf_stored_par)
-            elif check_fuzzy_boundary(par, np.min(irf_stored_par), tolerance, par_name, False):
+            elif check_fuzzy_boundary(par, np.min(irf_stored_par), tolerance, par_name):
                 par = np.min(irf_stored_par)
             else:
                 logging.error("Tolerance not calculated for coordinate {0}".format(par_name))
@@ -96,7 +96,7 @@ def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
     return par
 
 
-def check_fuzzy_boundary(par, boundary, tolerance, par_name, max_test=False):
+def check_fuzzy_boundary(par, boundary, tolerance, par_name):
     """" Checks if the parameter value is within the given tolerance.
     tolerance parameter is defined as ratio of absolute difference
     between boundary and par to the boundary.
@@ -107,7 +107,6 @@ def check_fuzzy_boundary(par, boundary, tolerance, par_name, max_test=False):
     boundary: lower or upper boundary value of stored IRF
     tolerance: allowed value of --fuzzy_boundary command line argument
     par_name: parameter name
-    max_test: check for maximum (if True)
 
     Returns
     -------
@@ -119,7 +118,7 @@ def check_fuzzy_boundary(par, boundary, tolerance, par_name, max_test=False):
         return False
 
     if boundary > 0:
-        fuzzy_diff = (par - boundary) / boundary
+        fuzzy_diff = np.abs(par - boundary) / boundary
         if fuzzy_diff < tolerance:
             logging.info(
                 "Coordinate {0} tolerance is {1:0.3f} and is within {2:0.3f}".format(

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -1,6 +1,6 @@
-import click
 import logging
 
+import click
 import numpy as np
 import uproot
 
@@ -100,7 +100,7 @@ def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
 
 
 def check_fuzzy_boundary(par, boundary, tolerance, par_name):
-    """ " Checks if the parameter value is within the given tolerance.
+    """ Checks if the parameter value is within the given tolerance.
     tolerance parameter is defined as ratio of absolute difference
     between boundary and par to the boundary.
 
@@ -306,7 +306,8 @@ def fill_direction_migration(
             rad_edges, r_low, r_high = bin_centers_to_edges(axis[1], logaxis=True)
 
             rad_width_deg = np.diff(np.power(10, rad_edges))
-            # this step makes sure all arrays have the same dimensions, rad_width_deg and the central rad values are
+            # this step makes sure all arrays have the same dimensions,
+            # rad_width_deg and the central rad values are
             # repeated by the length of the energy axis.
             norm = np.sum(
                 direction_diff

--- a/pyV2DL3/script/v2dl3_for_Eventdisplay.py
+++ b/pyV2DL3/script/v2dl3_for_Eventdisplay.py
@@ -5,6 +5,7 @@ from pyV2DL3.genHDUList import genHDUlist
 from pyV2DL3.genHDUList import loadROOTFiles
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+IRF_AXIS=["zenith", "pedvar"]
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -59,12 +60,13 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 )
 @click.option(
     "--fuzzy_boundary",
-    nargs=1,
-    type=click.FLOAT,
-    default=0.0,
+    multiple=True,
+    nargs=2,
+    type=(click.Choice(IRF_AXIS), click.FLOAT),
+    default=None,
     help="Parameter outside IRF range but within a given tolerance is interpolated\
 at boundary value. tolerance = ratio of absolute difference between boundary and parameter\
-value to boundary",
+value to boundary. Given for each IRF axes (zenith, pedvar) as key, value pair.",
 )
 def cli(
     file_pair,
@@ -109,7 +111,11 @@ def cli(
     anasum_str, ea_str = file_pair
     logging.info(f"Eventdisplay: anasum file {anasum_str}")
     logging.info(f"Effective: area file {ea_str}")
-    logging.info(f"Fuzzy boundary setting: {fuzzy_boundary}, force extrapolation: {force_extrapolation}")
+    logging.info(f"IRF axes force extrapolation: {force_extrapolation}")
+    if fuzzy_boundary is not None:
+        for key, value in fuzzy_boundary:
+            logging.info(f"Fuzzy boundary setting for {key} axis: {value}")
+
     datasource = loadROOTFiles(anasum_str, ea_str, "Eventdisplay")
     datasource.set_irfs_to_store(irfs_to_store)
     datasource.fill_data(evt_filter=evt_filter)

--- a/pyV2DL3/script/v2dl3_for_Eventdisplay.py
+++ b/pyV2DL3/script/v2dl3_for_Eventdisplay.py
@@ -5,7 +5,7 @@ from pyV2DL3.genHDUList import genHDUlist
 from pyV2DL3.genHDUList import loadROOTFiles
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
-IRF_AXIS=["zenith", "pedvar"]
+IRF_AXIS = ["zenith", "pedvar"]
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)

--- a/pyV2DL3/tests/test_fillRESPONSE.py
+++ b/pyV2DL3/tests/test_fillRESPONSE.py
@@ -1,4 +1,3 @@
-import logging
 import pytest
 
 from pyV2DL3.eventdisplay.fillRESPONSE import check_fuzzy_boundary

--- a/pyV2DL3/tests/test_fillRESPONSE.py
+++ b/pyV2DL3/tests/test_fillRESPONSE.py
@@ -7,24 +7,24 @@ from pyV2DL3.eventdisplay.fillRESPONSE import check_fuzzy_boundary
 def test_check_fuzzy_boundary(caplog):
 
     caplog.clear()
+    par_name = "pedvar"
     par = 7.9
     boundary = 7.86
     tolerance_1 = 0.05
     tolerance_2 = 0.001
 
-    check_fuzzy_boundary(par, boundary, tolerance_1)
+    check_fuzzy_boundary(par, boundary, tolerance_1, par_name)
 
-    assert caplog.record_tuples == [("root", logging.WARNING, "Coordinate tolerance is 0.005 and is within 0.050")]
-    assert check_fuzzy_boundary(par, boundary, tolerance_1) == 1
+    assert check_fuzzy_boundary(par, boundary, tolerance_1, par_name) == 1
 
     with pytest.raises(ValueError):
-        check_fuzzy_boundary(par, boundary, tolerance_2)
+        check_fuzzy_boundary(par, boundary, tolerance_2, par_name)
 
     boundary = 0.0
-    assert check_fuzzy_boundary(par, boundary, tolerance_1) == 0
+    assert check_fuzzy_boundary(par, boundary, tolerance_1, par_name) == 0
 
     boundary = -1.0
-    assert check_fuzzy_boundary(par, boundary, tolerance_1) == 0
+    assert check_fuzzy_boundary(par, boundary, tolerance_1, par_name) == 0
 
 
 if __name__ == "__main__":

--- a/utils/download_Eventdisplay_test_data.sh
+++ b/utils/download_Eventdisplay_test_data.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-wget --no-verbose https://syncandshare.desy.de/index.php/s/jsAwk3QD2CASsN2/download/github-CI.tar.gz
+wget --no-verbose https://syncandshare.desy.de/index.php/s/S8KAyRAmNdF9qEX/download/github-CI.tar.gz
 tar -xvzf github-CI.tar.gz


### PR DESCRIPTION
We have observations outside of the parameter space of our instrument response functions. These are typically very low-elevation runs (IRFs start at 30 deg elevation only; e.g., the Galactic center culminates below) or very dark/bright NSB runs.

IRF interpolation allows to extend slightly beyond the boundaries using the `---fuzzy_boundary` parameter. 

This pull request introduce IRF axes dependent `-fuzzy_boundary` parameters, with the motivation that the IRF dependence with zenith angle is much stronger than the one with pedvar (NSB). So there is good motivation to have a somewhat more relaxed fuzzy boundary for the NSB axes.

Instead of using `--fuzzy_boundary 0.05`, give now the tolerance per IRF axis:  `--fuzzy_boundary pedvar 0.10 --fuzzy_boundary zenith 0.05` (only those two axes are allowed).

This pull request also fixes a bug in the mean pedvar calculation (used for the IRF interpolation). For some runs, this is not filled correctly by anasum into the runSummary tree and we prefer now to calculate it from the values in the DL3 tree.

Note that [pyV2DL3/eventdisplay/fillRESPONSE.py](pyV2DL3/eventdisplay/fillRESPONSE.py) contains a lot of formatting changes (I've applied black, as the formatting was all over the place).
 