### PR TITLE
Replace call to ls by glob.glob

### DIFF
--- a/pyV2DL3/eventdisplay/IrfInterpolator.py
+++ b/pyV2DL3/eventdisplay/IrfInterpolator.py
@@ -1,11 +1,12 @@
-import click
 import logging
-import numpy as np
 import os.path
-from pyV2DL3.eventdisplay.IrfExtractor import extract_irf
-from pyV2DL3.eventdisplay.util import duplicate_dimensions
-from pyV2DL3.eventdisplay.util import WrongIrf
+
+import click
+import numpy as np
 from scipy.interpolate import RegularGridInterpolator
+
+from pyV2DL3.eventdisplay.IrfExtractor import extract_irf
+from pyV2DL3.eventdisplay.util import WrongIrf, duplicate_dimensions
 
 
 class IrfInterpolator:
@@ -90,7 +91,8 @@ class IrfInterpolator:
             extrapolation = kwargs.get("force_extrapolation", False)
 
         if extrapolation:
-            self.interpolator = RegularGridInterpolator(self.irf_axes, self.irf_data, bounds_error=False, fill_value=None)
+            self.interpolator = RegularGridInterpolator(
+                self.irf_axes, self.irf_data, bounds_error=False, fill_value=None)
         else:
             self.interpolator = RegularGridInterpolator(self.irf_axes, self.irf_data)
 
@@ -102,7 +104,7 @@ class IrfInterpolator:
         # The interpolation is slightly different for 1D or 2D IRFs.
         if self.azimuth == 0:
             if len(coordinate) != 4:
-                loging.error(
+                logging.error(
                     "IRF interpolation: for azimuth 0, require 4 coordinates "
                     "(azimuth,  pedvar, zenith, offset)"
                 )

--- a/pyV2DL3/script/generate_index_file.py
+++ b/pyV2DL3/script/generate_index_file.py
@@ -13,6 +13,7 @@ of each DL3 file.
 """
 
 import logging
+import glob
 import os
 
 import click
@@ -95,15 +96,10 @@ def cli(
 
     logging.debug("Start by searching all DL3 files in:\n{}".format(folder_location))
 
-    __fits_files = [
-        _file[:-1] for _file in list(os.popen(f"ls {folder_location}/[0-9]*.fits*"))
-    ]
-    print(len(__fits_files))
+    __fits_files = glob.glob(f"{folder_location}/[0-9]*.fits*")
     if len(__fits_files) == 0:
         logging.info("No FITS files found, trying Eventdisplay-style DL3 archive folder.")
-        __fits_files = [
-            _file[:-1] for _file in list(os.popen(f"ls {folder_location}/[0-9]*/[0-9]*.fits*"))
-        ]
+        __fits_files = glob.glob(f"{folder_location}/[0-9]*/[0-9]*.fits*")
     fits_files = [
         f
         for f in __fits_files
@@ -113,7 +109,7 @@ def cli(
         logging.error("No fits files found")
         return
 
-    logging.info("Found the following fits files:")
+    logging.info(f"Found the following {len(__fits_files)} fits files:")
     for f in fits_files:
         logging.info(" -> {0}".format(f))
 


### PR DESCRIPTION
This allows to read directories with a large number of fits files (beyond the limit of ls, which will give an error message /bin/sh: /bin/ls: Argument list too long)