### PR TITLE
Add pre-commit tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html#integration-with-pre-commit
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
+  # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        args: ["--max-line-length=100", "--extend-ignore=E203,E712"]
+  # https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer

--- a/environment-eventdisplay.yml
+++ b/environment-eventdisplay.yml
@@ -10,6 +10,8 @@ dependencies:
   - astropy>=4.0
   - click
   - numpy>=1.13
+  - pre-commit
+  - pyflakes
   - pytest
   - python>=3.8
   - pyyaml


### PR DESCRIPTION
This adds a pre-commit configuration file to run the following steps for each commit:

- flake8 linter
- sorting of imports
- remove trailing spaces

Run `pre-commit install` before using it first in the V2DL3 directory.