### PR TITLE
Add units to Xoff/Yoff; fixes in comments and writing

### DIFF
--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -368,7 +368,7 @@ def __fill_response__(
     theta_low, theta_high = find_camera_offsets(camera_offsets)
 
     if irf_to_store["point-like"]:
-        # Effective area (full-enclosure)
+        # Effective area (point-like)
         (
             response_dict["EA"],
             response_dict["LO_THRES"],

--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -88,7 +88,7 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None, event
     else:
         hdu1.header.set("INSTRUME", "VERITAS")
 
-    hdu1.header.set("OBS_ID  ", evt_dict["OBS_ID"], "run number")
+    hdu1.header.set("OBS_ID  ", evt_dict["OBS_ID"], "Run Number")
 
     hdu1.header.set(
         "DATE-OBS", evt_dict["DATE-OBS"], "start date (UTC) of obs yy-mm-dd hh:mm:ss"

--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -88,7 +88,7 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None, event
     else:
         hdu1.header.set("INSTRUME", "VERITAS")
 
-    hdu1.header.set("OBS_ID  ", evt_dict["OBS_ID"], "Run Number")
+    hdu1.header.set("OBS_ID  ", evt_dict["OBS_ID"], "run number")
 
     hdu1.header.set(
         "DATE-OBS", evt_dict["DATE-OBS"], "start date (UTC) of obs yy-mm-dd hh:mm:ss"

--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -54,8 +54,8 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None, event
     # Test if key exists in evt_dict. If yes, add these columns.
     add_existing_column(columns, evt_dict, name="ALT", format="1E", unit="deg")
     add_existing_column(columns, evt_dict, name="AZ", format="1E", unit="deg")
-    add_existing_column(columns, evt_dict, name="Xoff", format="1E")
-    add_existing_column(columns, evt_dict, name="Yoff", format="1E")
+    add_existing_column(columns, evt_dict, name="Xoff", format="1E", unit="deg")
+    add_existing_column(columns, evt_dict, name="Yoff", format="1E", unit="deg")
     add_existing_column(columns, evt_dict, name="MSW", format="1D")
     add_existing_column(columns, evt_dict, name="MSL", format="1D")
     add_existing_column(columns, evt_dict, name="IS_GAMMA", format="1L")

--- a/utils/download_Eventdisplay_test_data.sh
+++ b/utils/download_Eventdisplay_test_data.sh
@@ -14,5 +14,5 @@
 
 set -e
 
-wget --no-verbose https://syncandshare.desy.de/index.php/s/Pj4KBZ9E9cjLfk7/download/github-CI.tar.gz
+wget --no-verbose https://syncandshare.desy.de/index.php/s/qmxtgEC753L9LG6/download/github-CI.tar.gz
 tar -xvzf github-CI.tar.gz

--- a/utils/prepare_Eventdisplay_CI.sh
+++ b/utils/prepare_Eventdisplay_CI.sh
@@ -1,22 +1,31 @@
 #!/bin/bash
 # Prepare Eventdisplay CI files for integration tests
+#
+
+PDIR=$(pwd)
+
+echo "Preparing test data in ./test-eventdisplay-CI"
+mkdir -p test-eventdisplay-CI
+cd test-eventdisplay-CI
+../download_Eventdisplay_test_data.sh
+rm -f ED-*.fits.gz ED-*.log *.tar.gz
 
 # point-like tests
-python pyV2DL3/script/v2dl3_for_Eventdisplay.py \
+python ../../pyV2DL3/script/v2dl3_for_Eventdisplay.py \
     -f ./64080.anasum.root \
         ./effectiveArea.root \
         --logfile ED-pointlike-CI.log \
         ED-pointlike-CI.fits.gz
 
 # full-enclosure tests
-python pyV2DL3/script/v2dl3_for_Eventdisplay.py --full-enclosure \
+python ../../pyV2DL3/script/v2dl3_for_Eventdisplay.py --full-enclosure \
     -f ./64080.anasum.root \
        ./effectiveArea.root \
        --logfile ED-fullenclosure-CI.log \
        ED-fullenclosure-CI.fits.gz
 
 # point-like tests with DB
-python pyV2DL3/script/v2dl3_for_Eventdisplay.py \
+python ../../pyV2DL3/script/v2dl3_for_Eventdisplay.py \
     -f ./64080.anasum.root \
         ./effectiveArea.root \
         --db_fits_file ./64080.db.fits.gz \
@@ -24,7 +33,7 @@ python pyV2DL3/script/v2dl3_for_Eventdisplay.py \
         ED-pointlike-db-CI.fits.gz
 
 # point-like tests with event filter
-python pyV2DL3/script/v2dl3_for_Eventdisplay.py \
+python ../../pyV2DL3/script/v2dl3_for_Eventdisplay.py \
     -f ./64080.allevents.anasum.root \
        ./effectiveArea.root \
        --evt_filter eventfilter.yml \
@@ -32,9 +41,13 @@ python pyV2DL3/script/v2dl3_for_Eventdisplay.py \
        ED-pointlike-all-CI.fits.gz
 
 # full-enclosure tests with event selection
-python pyV2DL3/script/v2dl3_for_Eventdisplay.py --full-enclosure \
+python ../../pyV2DL3/script/v2dl3_for_Eventdisplay.py --full-enclosure \
      -f ./64080.allevents.anasum.root \
         ./effectiveArea.root \
         --evt_filter eventfilter.yml \
         --logfile ED-full-enclosure-all-CI.log \
         ED-full-enclosure-all-CI.fits.gz
+
+tar -cvzf github-CI.tar.gz *.root *.gz *.log *.yml
+
+cd ${PDIR}


### PR DESCRIPTION
Fixes:

- add units to Xoff/Xoff entries in event list
- consistent writing in lower case in FITS comments
