### PR TITLE
Update v2dl3-vegas.yml for setuptools-scm

### DIFF
--- a/.github/workflows/v2dl3-vegas.yml
+++ b/.github/workflows/v2dl3-vegas.yml
@@ -35,6 +35,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout new branch
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Pull docker image
         run: |
@@ -58,6 +60,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+          fetch-depth: 0
+
 
       - name: Install main branch and generate control outputs
         run: |

--- a/utils/vegas_docker_test_runs.sh
+++ b/utils/vegas_docker_test_runs.sh
@@ -39,10 +39,14 @@ export LANG=C.UTF-8
 
 set -e
 
+echo "Listing working dir:"
+ls
+echo "Listing ./.git:"
+ls .git
 echo "Installing v2dl3-vegas..."
 pip install --upgrade pip setuptools wheel setuptools_scm 
 pip list
-pip install -e . 
+pip install . 
 
 # ---------- TEST RUNS -----------
 function run_tests() 

--- a/utils/vegas_docker_test_runs.sh
+++ b/utils/vegas_docker_test_runs.sh
@@ -42,7 +42,7 @@ set -e
 echo "Installing v2dl3-vegas..."
 pip install --upgrade pip setuptools wheel setuptools_scm 
 pip list
-pip install . 
+pip install -e . 
 
 # ---------- TEST RUNS -----------
 function run_tests() 


### PR DESCRIPTION
Looking into the vegas-CI's log error, it seems Git's checkout@v3 action is likely not pulling the sufficient metadata from git for setuptools-scm.