### PR TITLE
v2dl3-vegas support for pypi install before and after PEP 517 and 621

### DIFF
--- a/.github/workflows/v2dl3-vegas.yml
+++ b/.github/workflows/v2dl3-vegas.yml
@@ -35,6 +35,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout new branch
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Pull docker image
         run: |
@@ -49,6 +51,7 @@ jobs:
           cp utils/compare_fits_dirs.sh ../compare_fits_dirs.sh
           docker run -p 80:80 -v $GITHUB_WORKSPACE:/$DOCKER_WORKSPACE $DOCKER_IMAGE /bin/bash -c "\
           cd $DOCKER_WORKSPACE \
+          && git config --global --add safe.directory /$DOCKER_WORKSPACE \
           && bash utils/vegas_docker_test_runs.sh OUTDIR=$NEW_DIR \
           "
           cp -r $NEW_DIR ../$NEW_DIR
@@ -58,12 +61,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Install main branch and generate control outputs
         run: |
           cp ../vegas_docker_test_runs_static.sh vegas_docker_test_runs_static.sh
           docker run -p 80:80 -v $GITHUB_WORKSPACE:/$DOCKER_WORKSPACE $DOCKER_IMAGE /bin/bash -c "\
           cd $DOCKER_WORKSPACE \
+          && git config --global --add safe.directory /$DOCKER_WORKSPACE \
           && bash vegas_docker_test_runs_static.sh OUTDIR=$CONTROL_DIR \
           "
           cp -r $CONTROL_DIR ../$CONTROL_DIR

--- a/.github/workflows/v2dl3-vegas.yml
+++ b/.github/workflows/v2dl3-vegas.yml
@@ -75,6 +75,7 @@ jobs:
 
       - name: Install fitsdiff
         run: |
+          sudo apt update
           sudo apt-get install -qq astropy-utils
 
       # A failure on this test simply means that at least one fits from the test batteries

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Install now pyV2DL3:
 pip install .
 ```
 
+On some setups, the following error may occur `LookupError: setuptools-scm was unable to detect version`. In this event, ensure that V2DL3 was cloned (`git clone`), then add the newly cloned V2DL3 to git's safe directories or grant it further permissions.
+
+```bash
+git config --global --add safe.directory
+```
+
 ### Docker recipe
 
 To use a Docker image with v2dl3-vegas pre-installed, see *utils/v2dl3-vegas-docker/README.md*

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import find_packages
+from setuptools import setup
+
+setup(
+    name="pyV2DL3",
+    version="0.5",
+    packages=find_packages(),
+    install_requires=[
+        "astropy",
+        "click",
+        "numpy",
+        "pkgconfig",
+        "pyyaml",
+        "scipy",
+        "tqdm",
+        "uproot",
+    ],
+    entry_points="""
+        [console_scripts]
+        v2dl3=pyV2DL3.script.v2dl3:main
+        v2dl3-vegas=pyV2DL3.script.v2dl3_for_vegas:cli
+        v2dl3_qsub=pyV2DL3.script.v2dl3_qsub:cli
+        generate_index_file=pyV2DL3.script.generate_index_file:cli
+    """,
+)

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@ setup(
         "tqdm",
         "uproot",
     ],
-    entry_points="""
-        [console_scripts]
-        v2dl3=pyV2DL3.script.v2dl3:main
-        v2dl3-vegas=pyV2DL3.script.v2dl3_for_vegas:cli
-        v2dl3_qsub=pyV2DL3.script.v2dl3_qsub:cli
-        generate_index_file=pyV2DL3.script.generate_index_file:cli
-    """,
+    entry_points={
+        "console_scripts": [
+            "v2dl3-vegas=pyV2DL3.script.v2dl3_for_vegas:cli",
+            "v2dl3-generate-index-file=pyV2DL3.script.generate_index_file:cli",
+            "v2dl3-eventdisplay=pyV2DL3.script.v2dl3_for_Eventdisplay:cli",
+        ]
+    },
 )

--- a/utils/vegas_docker_test_runs.sh
+++ b/utils/vegas_docker_test_runs.sh
@@ -41,7 +41,6 @@ set -e
 
 echo "Installing v2dl3-vegas..."
 pip install --upgrade pip setuptools wheel setuptools_scm 
-pip list
 pip install . 
 
 # ---------- TEST RUNS -----------
@@ -63,7 +62,7 @@ function run_tests()
     python3 utils/vegas_runlister.py runlist.txt -rd $STAGE5_DIR -e $EA_POINTLIKE_2 --no_prompt
     v2dl3-vegas $EXTRA_FLAGS --point-like -l runlist.txt $OUTDIR/point-like-2
 
-    # Coming in King PSF update....
+    # Full-enclosure tests not up to date....
 
     # echo "-------------------------------"
     # echo "Full-enclosure 1 - Min flags"
@@ -80,7 +79,6 @@ function run_tests()
     echo "-------------------------------"    
     echo "Single event class"
     echo "-------------------------------"
-
     python3 utils/vegas_runlister.py runlist.txt -rd $STAGE5_DIR -e $EA_EVCLASS_1 --no_prompt
     v2dl3-vegas -ec -l runlist.txt $OUTDIR/single-evclass
 


### PR DESCRIPTION
Happy to lend a hand when I can. Github @ tag or E-mail the address on my profile.

- `fetch-depth: 0` ensures the entire git metadata is checked out for setuptools-scm

- `git config --global --add safe.directory` should mostly only occur on VM's like Docker. I proposed adding a note about this to the README, since we documented and showed to users the docker recipes I made (V2DL3/utils/v2dl3-vegas-docker) as an easy way to run VEGAS and v2dl3-vegas without the heavy dependency setup (or on Windows, Mac, any Linux).

@GernotMaier I agree that it is preferable to remove setup.py. I attempted to on my test fork, and again when you raised the concern. On the CI, the install can run from the .toml file, but it does not install properly because the .toml is written using `[package]` syntax, supported by PEP 621+, which requires python 3.7+. The .toml may be able to be rewritten to PEP517, but that would essentially be setup.py wrapped in `[tools.setuptools]`. 

Unless VEGAS dependency support has been updated in the last year or so, it is difficult to get the latest Pythons working alongside a VEGAS install. VEGAS dependencies list Centos 6 or Ubuntu 16. The latest I could get working for the Docker recipes was Ubuntu 18, which supports up to Python 3.6. For these reasons, I would caution against a python 3.8 requirement. The install process will remain `pip install .` for all cases.

Setuptools doesn't seem to enforce its python requirement, perhaps for eventdisplay you might like to check python version at runtime and throw an error. Then only v2dl3-vegas would have to maintain the setup.py file, and we could add a comment stating such.