### PR TITLE
Run without Eventdisplay log file

### DIFF
--- a/pyV2DL3/eventdisplay/fillEVENTS.py
+++ b/pyV2DL3/eventdisplay/fillEVENTS.py
@@ -217,9 +217,8 @@ def __read_quality_flag_from_log(file, runNumber):
     try:
         return getRunQuality(file["run_{}/stereo/evndispLog".format(runNumber)].member("fLines"))
     except KeyError:
-        logging.error("Eventdisplay logfile not found in anasum root file")
-        logging.error("Please make sure to use Eventdisplay >= 486")
-        raise
+        logging.info("Eventdisplay logfile not found in anasum root file. Quality flag set to 0")
+    return 0
 
 
 def __get_ontime(file, runNumber, t_start_from_reference, t_stop_from_reference):


### PR DESCRIPTION
This PR allows to run V2DL3 on Eventdisplay anasum file without `evndispLog` object.

This was originally introduced to read the VPM quality flags from the log files (if the pointing monitor data was there or not). This is not necessary anymore, as the full run info and DQM information including the VPM status is not added to the header.

(and it `evndispLog` is not filled anymore with v490.7 into the anasum files to simplify the analysis chain).