### PR TITLE
Eventdisplay conversion - interpolation for non-regular IRF grids

### DIFF
--- a/environment-eventdisplay.yml
+++ b/environment-eventdisplay.yml
@@ -17,4 +17,5 @@ dependencies:
   - python>=3.11
   - pyyaml
   - scipy
+  - scikit-learn
   - uproot

--- a/pyV2DL3/eventdisplay/IrfExtractor.py
+++ b/pyV2DL3/eventdisplay/IrfExtractor.py
@@ -143,7 +143,7 @@ def extract_irf_2d(filename, irf_name, azimuth=None):
     - zeniths
     - woffs
 
-    For azimuth, select the azimuth bin closest to the given azimuth angle.
+    For azimuth, select the bin closest to the given azimuth angle.
 
     Parameters
     ----------

--- a/pyV2DL3/eventdisplay/IrfExtractor.py
+++ b/pyV2DL3/eventdisplay/IrfExtractor.py
@@ -93,9 +93,6 @@ def extract_irf_1d(filename, irf_name, azimuth=None):
     all_Woffs, woffs = load_parameter("Woff", fast_eff_area, az_mask)
 
     data = get_empty_ndarray([len(irf[0]), len(pedvars), len(zds), len(woffs)])
-    print("EEFF", len(irf[0]), len(pedvars), len(zds), len(woffs), len(irf))
-    print("VVVV", pedvars, zds, woffs, len(irf), len(all_pedvars), len(all_zds), len(all_Woffs))
-    print("ZZZZ", irf[0])
 
     for i in range(len(irf)):
         try:
@@ -116,7 +113,6 @@ def extract_irf_1d(filename, irf_name, azimuth=None):
         'zeniths': zds,
         'woffs': woffs
     }
-    print("DDDD", data.shape)
 
     return data, axes
 
@@ -228,7 +224,6 @@ def extract_irf_for_knn(filename, irf_name, irf1d=False, azimuth=None):
     woff = fast_eff_area["Woff"].array()[az_mask]
 
     if irf1d:
-        # 1D IRF case
         e0 = fast_eff_area["e0"].array()[az_mask]
         ze_b, pedvar_b, woff_b = ak.broadcast_arrays(e0, ze, pedvar, woff)[1:]
         coords = np.vstack([
@@ -239,7 +234,6 @@ def extract_irf_for_knn(filename, irf_name, irf1d=False, azimuth=None):
         ]).T
         values = ak.to_numpy(ak.flatten(fast_eff_area[irf_name].array()[az_mask]))
     else:
-        # 2D IRF case
         irf_axis_x = read_irf_axis("x", fast_eff_area, irf_name, az_mask)
         irf_axis_y = read_irf_axis("y", fast_eff_area, irf_name, az_mask)
         values = ak.to_numpy(ak.flatten(fast_eff_area[irf_name + "_value"].array()[az_mask]))
@@ -248,10 +242,9 @@ def extract_irf_for_knn(filename, irf_name, irf1d=False, azimuth=None):
         pedvar_rep = np.repeat(ak.to_numpy(pedvar), len(irf_axis_x)*len(irf_axis_y)).astype(np.float32)
         woff_rep = np.repeat(ak.to_numpy(woff), len(irf_axis_x)*len(irf_axis_y)).astype(np.float32)
 
-        irf_dim1 = np.tile(irf_axis_x, len(irf_axis_y))
-        irf_dim1 = np.tile(irf_dim1, len(ze))
-        irf_dim2 = np.tile(irf_axis_y, len(irf_axis_x))
-        irf_dim2 = np.tile(irf_dim2, len(ze))
+        xx, yy = np.meshgrid(irf_axis_x, irf_axis_y, indexing='xy')
+        irf_dim1 = np.tile(xx.flatten(), len(ze))
+        irf_dim2 = np.tile(yy.flatten(), len(ze))
 
         coords = np.vstack([
             pedvar_rep.flatten(),

--- a/pyV2DL3/eventdisplay/IrfInterpolator.py
+++ b/pyV2DL3/eventdisplay/IrfInterpolator.py
@@ -159,7 +159,7 @@ class IrfInterpolator:
 
     def _interpolate_2d(self, coordinate, irf_axes):
         """Interpolate IRF for 2D IRFs."""
-        xx, yy = np.meshgrid(self.irf_axes[0], self.irf_axes[1])
+        xx, yy = np.meshgrid(self.irf_axes[0], self.irf_axes[1], indexing='xy')
         xx_flat = xx.flatten()
         yy_flat = yy.flatten()
 

--- a/pyV2DL3/eventdisplay/IrfInterpolator.py
+++ b/pyV2DL3/eventdisplay/IrfInterpolator.py
@@ -22,8 +22,7 @@ class IrfInterpolator:
         self.irf_name = ""
         self.azimuth = azimuth
         self.interpolator = None
-        self.kNN = None
-        self.interpolator_name = "RegularGridInterpolator"
+        self.interpolator_name = "KNeighborsRegressor"
 
         if os.path.isfile(filename):
             self.filename = filename
@@ -39,8 +38,6 @@ class IrfInterpolator:
         ):
             self.irf_name = irf_name
             self._load_irf(**kwargs)
-            if irf_name in self.implemented_irf_names_1d:
-                self._load_irf_for_knn(**kwargs)
         else:
             logging.error(
                 "The irf you entered: {} is either wrong or not implemented.".format(
@@ -69,12 +66,21 @@ class IrfInterpolator:
         coords, values = extract_irf_for_knn(
             self.filename,
             self.irf_name,
-            irf1d=(self.irf_name in self.implemented_irf_names_1d),
+            irf1d=self.irf_name in self.implemented_irf_names_1d,
             azimuth=self.azimuth,
         )
-        self.kNN = KNeighborsRegressor(
-            n_neighbors=5, weights="distance")
-        self.kNN.fit(coords, values)
+        self.interpolator = KNeighborsRegressor(n_neighbors=5, weights="distance")
+        self.interpolator.fit(coords, values)
+
+        # Set irf_axes based on the coordinates
+        if self.irf_name in self.implemented_irf_names_1d:
+            self.irf_axes = [np.unique(coords[:, 3])]  # energy axis
+        else:
+            self.irf_axes = [
+                np.unique(coords[:, 3]),  # x dimension
+                np.unique(coords[:, 4])   # y dimension
+            ]
+        logging.debug(str(("IRF axes:", self.irf_axes)))
 
     def _load_irf_for_regular_grid_interpolator(self, **kwargs):
         """Load IRFs from file for RegularGridInterpolator"""
@@ -118,11 +124,6 @@ class IrfInterpolator:
         else:
             extrapolation = kwargs.get("force_extrapolation", False)
 
-        print("AAA", self.irf_axes, extrapolation)
-        print("IRF data shape:", self.irf_data.shape)
-        for i, axis_len in enumerate(self.irf_data.shape):
-            print(f"Axis {i} length: {axis_len}")
-
         if extrapolation:
             self.interpolator = RegularGridInterpolator(
                 self.irf_axes, self.irf_data, bounds_error=False, fill_value=None)
@@ -131,7 +132,6 @@ class IrfInterpolator:
 
     def interpolate(self, coordinate):
         coordinate[1] = np.cos(np.radians(coordinate[1]))
-        print("INTERPOLATE COORDINATE", coordinate, self.azimuth)
         for c in coordinate:
             logging.debug("Interpolating coordinates: {0:.2f}".format(c))
 
@@ -159,15 +159,19 @@ class IrfInterpolator:
 
     def _interpolate_2d(self, coordinate, irf_axes):
         """Interpolate IRF for 2D IRFs."""
-        print("2222", self.irf_name, irf_axes[0], irf_axes[1])
-        print("INTERPOLATE 2D COORDINATE", coordinate, self.azimuth)
+        xx, yy = np.meshgrid(self.irf_axes[0], self.irf_axes[1])
+        xx_flat = xx.flatten()
+        yy_flat = yy.flatten()
+
         try:
             if self.interpolator_name == "KNeighborsRegressor":
-                interpolated_irf = self.kNN.predict(
-                    np.array([[coordinate[0], coordinate[1], e, w] for e, w in zip(irf_axes[0], irf_axes[1])])
-                )
+                predict_coords = np.array([
+                    [coordinate[0], coordinate[1], coordinate[2], x, y]
+                    for x, y in zip(xx_flat, yy_flat)
+                ])
+                interpolated_irf = self.interpolator.predict(predict_coords)
+                interpolated_irf = interpolated_irf.reshape(xx.shape)
             else:
-                xx, yy = np.meshgrid(self.irf_axes[0], self.irf_axes[1])
                 interpolated_irf = self.interpolator((xx, yy, *coordinate))
         except ValueError:
             raise ValueError("IRF interpolation failed for axis %s", self.irf_name)
@@ -175,16 +179,14 @@ class IrfInterpolator:
 
     def _interpolate_1d(self, coordinate, irf_axis):
         """Interpolate IRF for 1D IRFs (energy axis only)."""
-        print("1111", self.irf_name, self.irf_axes)
-        print("INTERPOLATE 1D COORDINATE", coordinate, self.azimuth)
         try:
             if self.interpolator_name == "KNeighborsRegressor":
-                interpolated_irf = self.kNN.predict(
+                interpolated_irf = self.interpolator.predict(
                     np.array([[coordinate[0], coordinate[1], coordinate[2], e] for e in irf_axis])
                 )
             else:
                 interpolated_irf = self.interpolator((irf_axis, *coordinate))
         except ValueError:
             raise ValueError("IRF interpolation failed for axis %s", self.irf_name)
-        print("INTERPOLATED IRF", interpolated_irf)
+
         return interpolated_irf, [irf_axis]

--- a/pyV2DL3/eventdisplay/IrfInterpolator.py
+++ b/pyV2DL3/eventdisplay/IrfInterpolator.py
@@ -11,7 +11,7 @@ from pyV2DL3.eventdisplay.util import WrongIrf, duplicate_dimensions
 
 
 class IrfInterpolator:
-    def __init__(self, filename, azimuth):
+    def __init__(self, filename, azimuth, interpolator_name):
         self.implemented_irf_names_1d = ["eff", "Rec_eff", "effNoTh2", "Rec_effNoTh2"]
         self.implemented_irf_names_2d = [
             "hEsysMCRelative2D",
@@ -22,7 +22,13 @@ class IrfInterpolator:
         self.irf_name = ""
         self.azimuth = azimuth
         self.interpolator = None
-        self.interpolator_name = "KNeighborsRegressor"
+        self.interpolator_name = interpolator_name
+        if interpolator_name not in ["KNeighborsRegressor", "RegularGridInterpolator"]:
+            raise ValueError(
+                "The interpolator you entered: {} is either wrong or not implemented.".format(
+                    interpolator_name
+                )
+            )
 
         if os.path.isfile(filename):
             self.filename = filename
@@ -72,7 +78,6 @@ class IrfInterpolator:
         self.interpolator = KNeighborsRegressor(n_neighbors=5, weights="distance")
         self.interpolator.fit(coords, values)
 
-        # Set irf_axes based on the coordinates
         if self.irf_name in self.implemented_irf_names_1d:
             self.irf_axes = [np.unique(coords[:, 3])]  # energy axis
         else:

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -181,6 +181,7 @@ def fill_effective_area(
 ):
     """Effective areas"""
 
+    print("FFF set irf", irf_name)
     irf_interpolator.set_irf(irf_name, **kwargs)
 
     ea_final = []

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -352,8 +352,14 @@ def __fill_response__(
 
     response_dict = {}
 
+    if kwargs.get("use_click", True):
+        clk = click.get_current_context()
+        interpolator_name = clk.params["interpolator_name"]
+    else:
+        interpolator_name = kwargs.get("fuzzy_boundary", "KNeighborsRegressor")
+
     # IRF interpolator
-    irf_interpolator = IrfInterpolator(effective_area, azimuth)
+    irf_interpolator = IrfInterpolator(effective_area, azimuth, interpolator_name)
 
     # Extract camera offsets available from the effective areas file.
     fast_eff_area = uproot.open(effective_area)["fEffAreaH2F"]

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -181,7 +181,6 @@ def fill_effective_area(
 ):
     """Effective areas"""
 
-    print("FFF set irf", irf_name)
     irf_interpolator.set_irf(irf_name, **kwargs)
 
     ea_final = []

--- a/pyV2DL3/script/v2dl3_for_Eventdisplay.py
+++ b/pyV2DL3/script/v2dl3_for_Eventdisplay.py
@@ -76,6 +76,12 @@ value to boundary. Given for each IRF axes (zenith, pedvar) as key, value pair."
     help="FITS file containing the database tables (including DQM table).",
     default=None,
 )
+@click.option(
+    "--interpolator_name",
+    type=click.Choice(["KNeighborsRegressor", "RegularGridInterpolator"]),
+    help="Name of the interpolator to be used for IRF interpolation",
+    default="KNeighborsRegressor",
+)
 def cli(
     file_pair,
     full_enclosure,
@@ -90,6 +96,7 @@ def cli(
     force_extrapolation,
     fuzzy_boundary,
     db_fits_file,
+    interpolator_name,
 ):
     """Convert Eventdisplay anasum files and corresponding IRFs to DL3"""
     if len(file_pair) == 0:
@@ -125,6 +132,7 @@ def cli(
     if fuzzy_boundary is not None:
         for key, value in fuzzy_boundary:
             logging.info("Fuzzy boundary setting for %s axis: %s", key, value)
+    logging.info("IRF interpolator name: %s", interpolator_name)
     logging.info("Database FITS file: %s", db_fits_file)
 
     datasource = loadROOTFiles(anasum_str, ea_str, "Eventdisplay")


### PR DESCRIPTION
**This is work in progress and requires a lot more testing**

IRFs in DL3 files generated with V2DL3 <=v0.6.0 and v491 Eventdisplay files are wrong.

This is the issue:

- V2DL3 expects for a given Eventdisplay IRF file that the axes of the parameter space (zenith, azimuth, pedvars, camera offsets) are filled on a regular grid without any deviation. This allows to easily fill a regular grid with the IRFs and interpolate using scipy's RegularGridInterpolator. IRFs generated with Eventdisplay earlier than v491 are supposed to follow this criteria (but not that a single IRF files contains 180,000 IRFs generated from even more files / processes. So there might have been undetected issues before). The requirement of a regular grid is not checked anywhere in V2DL3 (clearly an omission)
-  IRFs for v491 (and future Eventdisplay versions) are not on a regular grid, as additional NSB and Ze bins have been added with different levels. 

This PR provides a solution by replacing the regular fit interpolation by a a kNN interpolator (using sklearn's  KNeighborsRegressor). This requires a bit of a different filling of the IRF axes plus reading.

Interpolators are selectable on the command line using `--interpolator_name` with the options "KNeighborsRegressor", "RegularGridInterpolator".