### PR TITLE
bugfix/negative_noise

### DIFF
--- a/pyV2DL3/vegas/fillEVENTS_not_safe.py
+++ b/pyV2DL3/vegas/fillEVENTS_not_safe.py
@@ -182,7 +182,7 @@ def __fillEVENTS_not_safe__(
         this_event_group["energyArr"].append(reco.fEnergy_GeV / 1000.0)
         this_event_group["nTelArr"].append(reco.fImages)
 
-        avNoise = 0 # Average Noise of telescopes for 1 event (i.e. not average of events)
+        avNoise = 0
         nTels = 0
         for telID in decodeConfigMask(runHeader.fRunInfo.fConfigMask):
             Noise = qStatsData.getCameraAverageTraceVar(

--- a/pyV2DL3/vegas/fillEVENTS_not_safe.py
+++ b/pyV2DL3/vegas/fillEVENTS_not_safe.py
@@ -216,7 +216,6 @@ def __fillEVENTS_not_safe__(
         for i, fNoise in enumerate(this_event_group["fNoise"]):
             if fNoise <= 0: #replace negative noises with average
                 this_event_group["fNoise"][i] = avNonNegativeNoises
-        logger.info(f"Successfully replaced negative noises for run {runHeader.getRunNumber()} with average noise for the run {avNonNegativeNoises:.3f}")
 
 
     avAlt = np.mean(avAlt)

--- a/pyV2DL3/vegas/fillEVENTS_not_safe.py
+++ b/pyV2DL3/vegas/fillEVENTS_not_safe.py
@@ -314,6 +314,8 @@ def __fillEVENTS_not_safe__(
         nTels += 1
 
     avNoise /= nTels
+    if avNoise <= 0:
+        logger.warning(f"Time independent noise of {avNoise} found for Run {runHeader.getRunNumber()}.")
 
     if st6_configs is not None:
         split_configs = {opt.split()[0]: opt.split()[1] for opt in st6_configs}


### PR DESCRIPTION
1. Added check for negative values returned from ``qStatsData.getCameraAverageTraceVar`` before filling ``this_event_group["fNoise"]``. If negative values exist for events in a timeslice, replace the noise values for events in that timeslice with the average for all other events in the run. 
2. Check for significant numbers of suppressed pixels. These lead to artificially low noise levels (not negative). I have set the limit to 200 pixels (i.e. 40% of one telescope or 50 pixels per telescope as this seems to be a reasonable threshold which doesn't throw errors if e.g. bright stars in field). If found, raises warning to cut entire timeslice. 
- An example of this occurring is timeslices 5, 6 and 7 in run 112640 where the HV was turned off and on again for a few minutes in the middle of the run due to headlights passing basecamp. See PedVars below: 

```
Determining pedvars (7 samples) timeslice info from VAQStatsData data....
Found 12 slices:
Slice:  0  2025-06-26 07:14:40.9362628 - 07:17:40.9490523, #Pedvars: 346, CamWPedVar: 9.302 9.467 9.164 9.595 (9.382)
Slice:  1  2025-06-26 07:17:40.9490523 - 07:20:40.9508081, #Pedvars: 350, CamWPedVar: 9.312 9.476 9.144 9.576 (9.377)
Slice:  2  2025-06-26 07:20:40.9508081 - 07:23:40.9672336, #Pedvars: 354, CamWPedVar: 9.288 9.488 9.160 9.613 (9.387)
Slice:  3  2025-06-26 07:23:40.9672336 - 07:26:40.9702794, #Pedvars: 352, CamWPedVar: 9.277 9.378 9.146 9.523 (9.331)
Slice:  4  2025-06-26 07:26:40.9702794 - 07:29:41.0000135, #Pedvars: 354, CamWPedVar: 9.337 9.436 9.169 9.595 (9.384)
Slice:  5  2025-06-26 07:29:41.0000135 - 07:32:41.0000138, #Pedvars: 358, CamWPedVar: 5.930 5.964 5.833 6.101 (5.957)
Slice:  6  2025-06-26 07:32:41.0000138 - 07:35:42.0000137, #Pedvars: 362, CamWPedVar: 1.818 1.560 1.718 1.718 (1.703)
Slice:  7  2025-06-26 07:35:42.0000137 - 07:38:42.0000139, #Pedvars: 354, CamWPedVar: 6.949 6.986 6.804 7.061 (6.950)
Slice:  8  2025-06-26 07:38:42.0000139 - 07:41:42.0062953, #Pedvars: 338, CamWPedVar: 9.269 9.475 9.268 9.666 (9.419)
Slice:  9  2025-06-26 07:41:42.0062953 - 07:44:42.0546676, #Pedvars: 350, CamWPedVar: 9.265 9.466 9.172 9.665 (9.392)
Slice: 10  2025-06-26 07:44:42.0546676 - 07:47:42.0587480, #Pedvars: 348, CamWPedVar: 9.371 9.511 9.256 9.695 (9.458)
Slice: 11  2025-06-26 07:47:42.0587480 - 07:50:44.2937440, #Pedvars: 350, CamWPedVar: 9.322 9.544 9.209 9.628 (9.426)
Averages:                                                                             8.179 8.285 8.061 8.425 (8.238)
```

- Note this change requires importing ctypes in ``/pyV2DL3/vegas/fillEVENTS_not_safe.py``. (This packages is already used in ``pyV2DL3/vegas/EffectiveAreaFile.py``)


3. Check for negative values returned from ``qStatsData.getCameraAverageTraceVarTimeIndpt``. If noise is negative or 0, add warning to logger. 