### PR TITLE
Fixing RADMAX Bug in VEGAS

### DIFF
--- a/pyV2DL3/script/v2dl3_for_vegas.py
+++ b/pyV2DL3/script/v2dl3_for_vegas.py
@@ -178,7 +178,7 @@ def cli(
         "event_class_mode": event_class_mode,
         "reco_type": reconstruction_type,
         "save_msw_msl": save_msw_msl,
-        "corr_EB_params" : energy_bias_corr,
+        "corr_EB_params": energy_bias_corr,
     }
 
     if psf_king is not None:
@@ -209,7 +209,7 @@ def cli(
         logging.info(f"Processing file: {st5_str}")
         logging.debug(f"Stage5 file:{st5_str}, Event classes:{ea_files}")
         fname_base = os.path.splitext(os.path.basename(st5_str))[0]
-        datasource_kwargs.update({"st6_configs" : st6_config})
+        datasource_kwargs.update({"st6_configs": st6_config})
         datasource = loadROOTFiles(st5_str, ea_files, "VEGAS", **datasource_kwargs)
         datasource.set_irfs_to_store(irfs_to_store)
         with cpp_print_context(verbose=verbose):
@@ -258,7 +258,7 @@ def cli(
         if not os.path.exists(output):
             os.makedirs(output)
         st5_str, ea_file = file_pair
-        ea_file = EffectiveAreaFile(ea_file,datasource_kwargs["reco_type"])
+        ea_file = EffectiveAreaFile(ea_file, datasource_kwargs["reco_type"])
         flist, failed_list, num_event_groups = processFilePair(
             st5_str,
             ea_file,
@@ -274,7 +274,9 @@ def cli(
         )
     # Runlist mode
     else:
-        file_pairs = runlist_to_file_pairs(runlist, event_class_mode, datasource_kwargs['reco_type'], output)
+        file_pairs = runlist_to_file_pairs(
+            runlist, event_class_mode, datasource_kwargs["reco_type"], output
+        )
         for st5_str, ea_file, st6_config in file_pairs:
 
             flist, failed_list, num_event_groups = processFilePair(
@@ -420,9 +422,14 @@ def runlist_to_file_pairs(runlist, event_class_mode, reco_type, output):
         if len(eas[runlist_id]) < 1:
             raise Exception("No EA filenames defined for runlist tag: " + runlist_id)
 
-        ea_files = [EffectiveAreaFile(ea,reco_type) for ea in eas[runlist_id]]
+        ea_files = [EffectiveAreaFile(ea, reco_type) for ea in eas[runlist_id]]
         if "CONFIG" in rl_dict.keys():
-            file_pairs.extend([(st5_file, ea_files, configs[runlist_id]) for st5_file in st5s[runlist_id]])
+            file_pairs.extend(
+                [
+                    (st5_file, ea_files, configs[runlist_id])
+                    for st5_file in st5s[runlist_id]
+                ]
+            )
         else:
             file_pairs.extend(
                 [(st5_file, ea_files, configs) for st5_file in st5s[runlist_id]]

--- a/pyV2DL3/script/v2dl3_for_vegas.py
+++ b/pyV2DL3/script/v2dl3_for_vegas.py
@@ -258,7 +258,7 @@ def cli(
         if not os.path.exists(output):
             os.makedirs(output)
         st5_str, ea_file = file_pair
-        ea_file = EffectiveAreaFile(ea_file)
+        ea_file = EffectiveAreaFile(ea_file,datasource_kwargs["reco_type"])
         flist, failed_list, num_event_groups = processFilePair(
             st5_str,
             ea_file,
@@ -274,7 +274,7 @@ def cli(
         )
     # Runlist mode
     else:
-        file_pairs = runlist_to_file_pairs(runlist, event_class_mode, output)
+        file_pairs = runlist_to_file_pairs(runlist, event_class_mode, datasource_kwargs['reco_type'], output)
         for st5_str, ea_file, st6_config in file_pairs:
 
             flist, failed_list, num_event_groups = processFilePair(
@@ -377,7 +377,7 @@ Returns:
 """
 
 
-def runlist_to_file_pairs(runlist, event_class_mode, output):
+def runlist_to_file_pairs(runlist, event_class_mode, reco_type, output):
     from pyV2DL3.vegas.parseSt6RunList import (
         RunlistParsingError,
         RunlistValidationError,
@@ -420,7 +420,7 @@ def runlist_to_file_pairs(runlist, event_class_mode, output):
         if len(eas[runlist_id]) < 1:
             raise Exception("No EA filenames defined for runlist tag: " + runlist_id)
 
-        ea_files = [EffectiveAreaFile(ea) for ea in eas[runlist_id]]
+        ea_files = [EffectiveAreaFile(ea,reco_type) for ea in eas[runlist_id]]
         if "CONFIG" in rl_dict.keys():
             file_pairs.extend([(st5_file, ea_files, configs[runlist_id]) for st5_file in st5s[runlist_id]])
         else:

--- a/pyV2DL3/vegas/EffectiveAreaFile.py
+++ b/pyV2DL3/vegas/EffectiveAreaFile.py
@@ -23,7 +23,7 @@ https://veritas.sao.arizona.edu/wiki/V2dl3_dev_notes#Event_Classes
 
 
 class EffectiveAreaFile(object):
-    def __init__(self, effective_area_file,reco_type=1):
+    def __init__(self, effective_area_file, reco_type=1):
         self.__vegas__ = VEGASStatus()
         self.__vegas__.loadVEGAS()
         self.effective_area_IO = ROOT.VARootIO(effective_area_file, True)
@@ -41,13 +41,13 @@ class EffectiveAreaFile(object):
             "FoVCutUpper",
             "FoVCutLower",
         ]
-        if reco_type==1:
-            cut_searches.append('ThetaSquareUpper')
-        elif reco_type ==2:
-            cut_searches.append('Model3DThetaSquareUpper')
+        if reco_type == 1:
+            cut_searches.append("ThetaSquareUpper")
+        elif reco_type == 2:
+            cut_searches.append("Model3DThetaSquareUpper")
 
         # Initialize corresponding class variables and default values
-        self.reco_type=reco_type
+        self.reco_type = reco_type
         self.theta_square_upper = None
         self.msw_lower = float("-inf")
         self.msw_upper = float("inf")
@@ -117,7 +117,9 @@ class EffectiveAreaFile(object):
         minEnergy, maxEnergy = c_float(), c_float()
         if st6_configs is not None:
             split_configs = {
-                opt.split(" ")[0]: opt.split(" ")[1] for opt in st6_configs if st6_configs is not None
+                opt.split(" ")[0]: opt.split(" ")[1]
+                for opt in st6_configs
+                if st6_configs is not None
             }
             if "EA_SafeEnergyRangeMethod" in split_configs.keys():
                 safe_energy_method = str(split_configs["EA_SafeEnergyRangeMethod"])

--- a/pyV2DL3/vegas/EffectiveAreaFile.py
+++ b/pyV2DL3/vegas/EffectiveAreaFile.py
@@ -23,7 +23,7 @@ https://veritas.sao.arizona.edu/wiki/V2dl3_dev_notes#Event_Classes
 
 
 class EffectiveAreaFile(object):
-    def __init__(self, effective_area_file):
+    def __init__(self, effective_area_file,reco_type=1):
         self.__vegas__ = VEGASStatus()
         self.__vegas__.loadVEGAS()
         self.effective_area_IO = ROOT.VARootIO(effective_area_file, True)
@@ -34,7 +34,6 @@ class EffectiveAreaFile(object):
 
         # Initialize the cuts parameter names to search for
         cut_searches = [
-            "ThetaSquareUpper",
             "MeanScaledWidthLower",
             "MeanScaledWidthUpper",
             "MaxHeightLower",
@@ -42,8 +41,13 @@ class EffectiveAreaFile(object):
             "FoVCutUpper",
             "FoVCutLower",
         ]
+        if reco_type==1:
+            cut_searches.append('ThetaSquareUpper')
+        elif reco_type ==2:
+            cut_searches.append('Model3DThetaSquareUpper')
 
         # Initialize corresponding class variables and default values
+        self.reco_type=reco_type
         self.theta_square_upper = None
         self.msw_lower = float("-inf")
         self.msw_upper = float("inf")
@@ -159,6 +163,8 @@ class EffectiveAreaFile(object):
                 + " must be < MeanScaledWidthUpper: "
                 + str(self.msw_upper)
             )
+        if self.reco_type == 2:
+            ea_cut_dict["ThetaSquareUpper"] = ea_cut_dict.pop("Model3DThetaSquareUpper")
 
         # Theta^2 cut is required
         if "ThetaSquareUpper" in ea_cut_dict:

--- a/pyV2DL3/vegas/fillRESPONSE_not_safe.py
+++ b/pyV2DL3/vegas/fillRESPONSE_not_safe.py
@@ -23,6 +23,7 @@ def __fillRESPONSE_not_safe__(
     response_dict["LO_THRES"] = minEnergy
     response_dict["HI_THRES"] = maxEnergy
 
+    logger.debug(f'RAD_MAX = {np.sqrt(effective_area_file.theta_square_upper)}')
     # Point-like
     if irf_to_store["point-like"]:
         response_dict["EA"] = ea_final_data

--- a/pyV2DL3/vegas/util.py
+++ b/pyV2DL3/vegas/util.py
@@ -66,7 +66,6 @@ def getCuts(config_str_ori, cut_searches):
         else:
             for cut_search in cut_searches:
                 if line.find(cut_search) >= 0:
-                    logger.debug(line)
                     key, cut_str = line.split(" ")
                     if key == cut_search:
                         if len(cut_str) > 0:

--- a/pyV2DL3/vegas/util.py
+++ b/pyV2DL3/vegas/util.py
@@ -57,6 +57,7 @@ Returns:
 
 def getCuts(config_str_ori, cut_searches):
     config_str = str(config_str_ori)
+    logger.debug(f"Searching for cuts {cut_searches} in config string:\n{config_str}")
     cuts_found = {}
     for line in config_str.splitlines():
         # Skip comment lines
@@ -65,9 +66,12 @@ def getCuts(config_str_ori, cut_searches):
         else:
             for cut_search in cut_searches:
                 if line.find(cut_search) >= 0:
+                    logger.debug(line)
                     key, cut_str = line.split(" ")
-                    if len(cut_str) > 0:
-                        cuts_found[cut_search] = cut_str
+                    if key == cut_search:
+                        if len(cut_str) > 0:
+                            cuts_found[cut_search] = cut_str
+    logger.debug(f'Found Cuts! {cut_searches} with {cuts_found}')
     return cuts_found
 
 


### PR DESCRIPTION
RADMAX was being improperly set in some VEGAS files. This appears to be due to an error where Model3DThetaSquareCut was always being read regardless of the reconstruction set by the user. I've now passed reco_type to the appropriate section and ensured that it matches. 

I tested runlist and file type import and tried with improper and proper reco_type and it all appears to be working well. 

Example test:
`v2dl3-vegas -d --point-like -r 2 -f /homes/wang/lundym/debuggingforothers/bryan/20260218/103110.root /raid/reedbuck/lundym/irf_alloff/ea_ITMgeo_24s_CARE162d12_v259rc0v2p1GT_alloff_Z0-60_s700_W1p1_L1p3_MH7_ThSq0p005_4nsb.root out`
gives:
`RAD_MAX =  0.07071067811865475 / Direction cut applied [deg]`

and the command (note -r 1):
`v2dl3-vegas -d --point-like -r 1 -f /homes/wang/l
undym/debuggingforothers/bryan/20260218/103110.root /raid/reedbuck/lundym/irf_alloff/ea_ITMgeo_24s_CAR
E162d12_v259rc0v2p1GT_alloff_Z0-60_s700_W1p1_L1p3_MH7_ThSq0p005_4nsb.root out`
and returns
`RAD_MAX =                360.0 / Direction cut applied [deg] `

The behavior now forces the user to correctly match the reconstruction to the right IRF. Currently there is no check that does this but it may be nice to include.