### PR TITLE
Eventdisplay file conversion: apply fuzzy boundary checks for large zenith angles only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
   # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html#integration-with-pre-commit
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 9.0.0b5
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
   # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         args: ["--max-line-length=125", "--extend-ignore=E203,E712"]
   # https://github.com/pre-commit/pre-commit-hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -21,17 +21,17 @@ repos:
         args: ['--maxkb=500']
   # Github action
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.4
+    rev: v1.7.12
     hooks:
       - id: actionlint
   # https://pyproject-fmt.readthedocs.io/en/latest/
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.5.0"
+    rev: "v2.28.0"
     hooks:
       - id: pyproject-fmt
   # codespell
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.3
     hooks:
       - id: codespell
         args: [
@@ -39,13 +39,13 @@ repos:
         ]
   # markdownlint
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.43.0
+    rev: v0.49.1
     hooks:
       - id: markdownlint
         args: ["--disable", "MD041"]
   # yamllint
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args: ["--strict", "-d", '{rules: {line-length: {max: 250}}}']

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Runs with observational parameters (i.e., zenith, night sky background) outside 
 - `--fuzzy_boundary tolerance`: This option interpolates the IRF at the boundary value if the run parameter value is within the given tolerance. The tolerance is define as the ratio of absolute difference between boundary and run parameter value to boundary. This option is preferable over `--force_extrapolation`.
 - `--force_extrapolation`: This option extrapolates linearly the IRF at the run parameter value. Use this option with a caution since the extrapolation is applied even for run parameter values very far from the corresponding IRF axes range.
 
-Recommended options is: `--fuzzy_boundary zenith 0.05 --fuzzy_boundary pedvar 0.5`.
-For zenith values below 30 degrees and below the lowest available IRF zenith, the lowest IRF boundary is used. The fuzzy-boundary tolerance remains enforced for large zenith angles, where shower properties change significantly with small changes in zenith angle.
+Recommended options are: `--fuzzy_boundary zenith 0.05 --fuzzy_boundary pedvar 0.5`.
+For zenith values below 30 degrees and below the lowest available value on the IRF zenith axis, the lowest IRF boundary is used. The fuzzy boundary tolerance remains enforced for large zenith angles, where shower properties change significantly with small changes in zenith angle.
 
 Further options are:
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Runs with observational parameters (i.e., zenith, night sky background) outside 
 - `--force_extrapolation`: This option extrapolates linearly the IRF at the run parameter value. Use this option with a caution since the extrapolation is applied even for run parameter values very far from the corresponding IRF axes range.
 
 Recommended options is: `--fuzzy_boundary zenith 0.05 --fuzzy_boundary pedvar 0.5`.
-This takes into account that extrapolation of the IRF zenith axis is applied to very large zenith angles only, where shower properties changes significantly with small changes in zenith angle.
+For zenith values below 30 degrees and below the lowest available IRF zenith, the lowest IRF boundary is used. The fuzzy-boundary tolerance remains enforced for large zenith angles, where shower properties change significantly with small changes in zenith angle.
 
 Further options are:
 

--- a/pyV2DL3/eventdisplay/fillRESPONSE.py
+++ b/pyV2DL3/eventdisplay/fillRESPONSE.py
@@ -9,6 +9,12 @@ from pyV2DL3.eventdisplay.util import bin_centers_to_edges
 
 logger = logging.getLogger(__name__)
 
+# At low zenith angles the IRF dependence is sufficiently weak that the
+# lowest available zenith IRF can be used as a boundary value.  The fuzzy
+# boundary check remains strict for larger zenith angles, where extrapolation
+# has a larger impact on the IRFs.
+LOW_ZENITH_BOUNDARY = 30.0
+
 
 class FullEnclosureOffsetAxisError(Exception):
     pass
@@ -84,6 +90,18 @@ def check_parameter_range(par, irf_stored_par, par_name, **kwargs):
                 par, np.max(irf_stored_par), tolerance, par_name
             ):
                 par = np.max(irf_stored_par)
+            elif (
+                par_name == "zenith"
+                and np.all(irf_stored_par > par)
+                and par < LOW_ZENITH_BOUNDARY
+            ):
+                logging.warning(
+                    "Coordinate zenith ({0:.1f} deg) is below the IRF range; "
+                    "using the lower boundary ({1:.1f} deg)".format(
+                        par, np.min(irf_stored_par)
+                    )
+                )
+                par = np.min(irf_stored_par)
             elif np.all(irf_stored_par > par) and check_fuzzy_boundary(
                 par, np.min(irf_stored_par), tolerance, par_name
             ):

--- a/pyV2DL3/tests/test_fillRESPONSE.py
+++ b/pyV2DL3/tests/test_fillRESPONSE.py
@@ -1,6 +1,10 @@
+import numpy as np
 import pytest
 
-from pyV2DL3.eventdisplay.fillRESPONSE import check_fuzzy_boundary
+from pyV2DL3.eventdisplay.fillRESPONSE import (
+    check_fuzzy_boundary,
+    check_parameter_range,
+)
 
 
 def test_check_fuzzy_boundary(caplog):
@@ -24,6 +28,43 @@ def test_check_fuzzy_boundary(caplog):
 
     boundary = -1.0
     assert check_fuzzy_boundary(par, boundary, tolerance_1, par_name) == 0
+
+
+def test_low_zenith_uses_lower_irf_boundary(caplog):
+    caplog.clear()
+
+    result = check_parameter_range(
+        12.0,
+        np.array([20.0, 40.0, 60.0]),
+        "zenith",
+        use_click=False,
+        fuzzy_boundary=0.05,
+    )
+
+    assert result == 20.0
+    assert "using the lower boundary" in caplog.text
+
+
+def test_high_zenith_still_requires_fuzzy_boundary():
+    with pytest.raises(ValueError):
+        check_parameter_range(
+            65.0,
+            np.array([20.0, 40.0, 60.0]),
+            "zenith",
+            use_click=False,
+            fuzzy_boundary=0.05,
+        )
+
+
+def test_pedvar_lower_boundary_remains_strict():
+    with pytest.raises(ValueError):
+        check_parameter_range(
+            2.0,
+            np.array([5.0, 7.0]),
+            "pedvar",
+            use_click=False,
+            fuzzy_boundary=0.05,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There is max value for interpolation, which should be applied at large zenith angles only. We currently remove very small zenith angle runs, e.g.

```
INFO:v2dl3: Parameters used to query IRFs: az=283.56 deg, ze=11.97 deg, pedvar=6.5
INFO:v2dl3: Extracting Full-enclosure IRFs for zenith: 12.0 deg, pedvar: 6.5
INFO:v2dl3: 	camera offset:  0.50,
INFO:v2dl3: 	zenith range of a given IRF: 20.00 - 60.00
ERROR:v2dl3: Coordinate zenith tolerance is 0.402 and is outside 0.050
```

This PR prevents this and applies this cut only for >30deg ze.

Note that this is only an issue for some specialized conditions (e.g., UV-filter runs).