### PR TITLE
Eventdisplay: Fix DB metadata association

### DIFF
--- a/pyV2DL3/eventdisplay/DBFitsFile.py
+++ b/pyV2DL3/eventdisplay/DBFitsFile.py
@@ -150,11 +150,6 @@ def read_db_fits_file(db_fits_file, run_number=None, protected_keys=()):
                 "DQM column {!r} would overwrite core "
                 "Eventdisplay metadata".format(column)
             )
-        if normalised_column in protected_columns:
-            raise ValueError(
-                "DQM column {!r} would overwrite core "
-                "Eventdisplay metadata".format(column)
-            )
         canonical_name = supported_columns.get(normalised_column)
         if canonical_name is not None:
             db_dict[canonical_name] = _scalar_value(row[column])

--- a/pyV2DL3/eventdisplay/DBFitsFile.py
+++ b/pyV2DL3/eventdisplay/DBFitsFile.py
@@ -9,23 +9,98 @@ import astropy.io.registry
 import numpy as np
 from astropy.table import Table
 
+from pyV2DL3.fillEVENTS import non_standard_hdu_keys_and_comments
+
 logger = logging.getLogger(__name__)
 
 
-def read_db_fits_file(db_fits_file):
+# DQM columns that are intentionally exposed as optional EVENTS headers.  All
+# other DQM columns are ignored so that an arbitrary database column cannot
+# become part of the conversion state by accident.
+SUPPORTED_DB_COLUMNS = frozenset(non_standard_hdu_keys_and_comments())
+
+# The DQM row identifier has had several spellings in database exports.  The
+# first matching name below is preferred, while matching itself is
+# case/underscore insensitive.
+RUN_ID_COLUMNS = (
+    "runNumber",
+    "run_number",
+    "run_id",
+    "run",
+    "obs_id",
+    "OBS_ID",
+)
+
+
+def _normalise_name(name):
+    """Normalize FITS column names for matching known fields."""
+
+    return "".join(
+        character.lower() for character in str(name) if character.isalnum()
+    )
+
+
+def _normalise_run_id(value):
+    """Return a comparable scalar run identifier."""
+
+    if np.ma.is_masked(value) or value is None:
+        return None
+
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return str(value).strip()
+
+    if numeric_value.is_integer():
+        return int(numeric_value)
+    return numeric_value
+
+
+def _scalar_value(value):
+    """Convert FITS scalar values to ordinary Python values."""
+
+    if np.ma.is_masked(value):
+        return None
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _find_run_id_column(column_names):
+    """Find the preferred run identifier column in a DQM table."""
+
+    by_normalised_name = {
+        _normalise_name(name): name for name in column_names
+    }
+    for candidate in RUN_ID_COLUMNS:
+        column = by_normalised_name.get(_normalise_name(candidate))
+        if column is not None:
+            return column
+    return None
+
+
+def read_db_fits_file(db_fits_file, run_number=None, protected_keys=()):
     """
-    Read DB FITS file and return a dictionary with the DQM table
+    Read the DQM metadata for one run.
+
+    A database file is only safe to use when its DQM row is associated with
+    the run being converted.  Therefore a run number is required whenever a
+    database file is supplied, and exactly one matching row must exist.
+    ``protected_keys`` contains metadata already derived from the anasum file;
+    a DQM column matching one of those keys is rejected instead of replacing
+    it.
 
     """
 
     db_dict = {}
     if db_fits_file is None:
         return db_dict
+    if run_number is None:
+        raise ValueError("run_number is required when reading a DB FITS file")
 
     logger.info("Reading DB FITS file: %s", db_fits_file)
     try:
         db_table = Table.read(db_fits_file, hdu="DQM")
-        db_dict = {key: value[0] for key, value in db_table.items()}
     except FileNotFoundError:
         logger.error("DB FITS file not found: %s", db_fits_file)
         raise
@@ -33,8 +108,58 @@ def read_db_fits_file(db_fits_file):
         logger.error("DB FITS file is not a FITS file: %s", db_fits_file)
         raise
     except KeyError:
-        logger.error("DB FITS file does not contain DQM table: %s", db_fits_file)
+        logger.error(
+            "DB FITS file does not contain DQM table: %s", db_fits_file
+        )
         raise
+
+    run_id_column = _find_run_id_column(db_table.colnames)
+    if run_id_column is None:
+        raise ValueError(
+            "DQM table in {} has no supported run identifier column; "
+            "expected one of {}".format(db_fits_file, RUN_ID_COLUMNS)
+        )
+
+    expected_run = _normalise_run_id(run_number)
+    matching_rows = [
+        index
+        for index, value in enumerate(db_table[run_id_column])
+        if _normalise_run_id(value) == expected_run
+    ]
+    if len(matching_rows) != 1:
+        raise ValueError(
+            "DQM table in {} has {} rows for run {} "
+            "(expected exactly one)".format(
+                db_fits_file, len(matching_rows), run_number
+            )
+        )
+
+    row = db_table[matching_rows[0]]
+    supported_columns = {
+        _normalise_name(column): column for column in SUPPORTED_DB_COLUMNS
+    }
+    protected_columns = {_normalise_name(key) for key in protected_keys}
+    run_id_name = _normalise_name(run_id_column)
+
+    for column in db_table.colnames:
+        normalised_column = _normalise_name(column)
+        if normalised_column == run_id_name:
+            continue
+        if normalised_column in protected_columns:
+            raise ValueError(
+                "DQM column {!r} would overwrite core "
+                "Eventdisplay metadata".format(column)
+            )
+        if normalised_column in protected_columns:
+            raise ValueError(
+                "DQM column {!r} would overwrite core "
+                "Eventdisplay metadata".format(column)
+            )
+        canonical_name = supported_columns.get(normalised_column)
+        if canonical_name is not None:
+            db_dict[canonical_name] = _scalar_value(row[column])
+        else:
+            logger.debug("Ignoring unsupported DQM column %s", column)
 
     ensure_nan_instead_masked_arrays(db_dict)
 

--- a/pyV2DL3/eventdisplay/fillEVENTS.py
+++ b/pyV2DL3/eventdisplay/fillEVENTS.py
@@ -68,7 +68,11 @@ def __fillEVENTS__(edFileIO, select=None, db_fits_file=None):
             __get_ontime(file, runNumber, t_start_from_reference, t_stop_from_reference)
         evt_dict["LIVETIME"] = evt_dict["ONTIME"] * evt_dict["DEADC"]
 
-    evt_dict.update(read_db_fits_file(db_fits_file))
+    evt_dict.update(
+        read_db_fits_file(
+            db_fits_file, runNumber, protected_keys=evt_dict.keys()
+        )
+    )
 
     return (
         {

--- a/pyV2DL3/tests/test_eventdisplay_units.py
+++ b/pyV2DL3/tests/test_eventdisplay_units.py
@@ -97,20 +97,52 @@ def test_event_list_helpers_apply_selection_and_reject_an_empty_result():
 
 def test_db_fits_reader_converts_masked_values(monkeypatch):
     table = Table()
-    table["weather"] = ["A"]
-    table.add_column(MaskedColumn([1.0], mask=[True], name="l3_rate_mean"))
+    table["runNumber"] = [41, 42]
+    table["weather"] = ["B", "A"]
+    table.add_column(
+        MaskedColumn([1.0, 2.0], mask=[False, True], name="l3_rate_mean")
+    )
+    table["unsupported"] = [1, 2]
     monkeypatch.setattr(DBFitsFile.Table, "read", Mock(return_value=table))
 
-    assert DBFitsFile.read_db_fits_file("run.db.fits") == {
+    assert DBFitsFile.read_db_fits_file("run.db.fits", 42) == {
         "weather": "A", "l3_rate_mean": None
     }
     assert DBFitsFile.read_db_fits_file(None) == {}
 
 
+def test_db_fits_reader_rejects_missing_or_ambiguous_run_metadata(monkeypatch):
+    table = Table()
+    table["runNumber"] = [41, 43]
+    table["weather"] = ["B", "A"]
+    monkeypatch.setattr(DBFitsFile.Table, "read", Mock(return_value=table))
+
+    with pytest.raises(ValueError, match="expected exactly one"):
+        DBFitsFile.read_db_fits_file("run.db.fits", 42)
+
+    table["runNumber"] = [42, 42]
+    with pytest.raises(ValueError, match="expected exactly one"):
+        DBFitsFile.read_db_fits_file("run.db.fits", 42)
+
+
+def test_db_fits_reader_rejects_core_metadata_collisions(monkeypatch):
+    table = Table()
+    table["runNumber"] = [42]
+    table["OBS_ID"] = [999]
+    monkeypatch.setattr(DBFitsFile.Table, "read", Mock(return_value=table))
+
+    with pytest.raises(ValueError, match="overwrite core"):
+        DBFitsFile.read_db_fits_file(
+            "run.db.fits", 42, protected_keys={"OBS_ID"}
+        )
+
+
 def test_db_fits_reader_preserves_read_errors(monkeypatch):
-    monkeypatch.setattr(DBFitsFile.Table, "read", Mock(side_effect=FileNotFoundError))
+    monkeypatch.setattr(
+        DBFitsFile.Table, "read", Mock(side_effect=FileNotFoundError)
+    )
     with pytest.raises(FileNotFoundError):
-        DBFitsFile.read_db_fits_file("missing.db.fits")
+        DBFitsFile.read_db_fits_file("missing.db.fits", 42)
 
 
 def test_data_source_passes_event_and_response_options(monkeypatch, tmp_path):
@@ -187,7 +219,8 @@ def test_event_builder_combines_run_metadata_events_gti_and_db_metadata(monkeypa
     monkeypatch.setattr(fill_events, "__get_average_event_direction", Mock(return_value=(50.0, 180.0)))
     monkeypatch.setattr(fill_events, "__read_quality_flag_from_log", Mock(return_value=0))
     monkeypatch.setattr(fill_events, "__get_ontime", Mock(return_value=([10.0], [18.0], 8.0)))
-    monkeypatch.setattr(fill_events, "read_db_fits_file", Mock(return_value={"weather": "A"}))
+    db_reader = Mock(return_value={"weather": "A"})
+    monkeypatch.setattr(fill_events, "read_db_fits_file", db_reader)
 
     gti, irf_query, events = fill_events.__fillEVENTS__("events.root", db_fits_file="run.db.fits")
 
@@ -197,6 +230,9 @@ def test_event_builder_combines_run_metadata_events_gti_and_db_metadata(monkeypa
     assert events["LIVETIME"] == pytest.approx(7.2)
     assert events["TELLIST"] == "T1,T2"
     assert events["weather"] == "A"
+    db_reader.assert_called_once_with(
+        "run.db.fits", 42, protected_keys=events.keys()
+    )
 
 
 def test_irf_extraction_and_interpolation_accept_north_azimuth(tmp_path, monkeypatch):


### PR DESCRIPTION
Ensure Eventdisplay DB-FITS metadata is safely associated with the converted run.

- Require exactly one matching DQM row.
- Reject missing, wrong, or duplicate run matches.
- Ignore unsupported DQM columns.
- Prevent database metadata from overwriting anasum-derived values.
- Add regression tests for matching, ambiguous, masked, and conflicting metadata.

