### PR TITLE
Fix comparison command exit status

### DIFF
--- a/pyV2DL3/script/compareFitsFiles.py
+++ b/pyV2DL3/script/compareFitsFiles.py
@@ -28,6 +28,8 @@ def cli(file_pair, diff_file):
 
     fd = fits.FITSDiff(file1, file2, rtol=1.e-4, ignore_keywords=["CREATOR"])
     fd.report(diff_file, overwrite=True)
+    if not fd.identical:
+        raise click.exceptions.Exit(1)
 
 
 if __name__ == "__main__":

--- a/pyV2DL3/tests/test_compareFitsFiles.py
+++ b/pyV2DL3/tests/test_compareFitsFiles.py
@@ -1,0 +1,38 @@
+import numpy as np
+from astropy.io import fits
+from click.testing import CliRunner
+
+from pyV2DL3.script.compareFitsFiles import cli
+
+
+def write_fits(path, value):
+    fits.PrimaryHDU(data=np.array([value], dtype=np.int16)).writeto(path)
+
+
+def test_compare_fits_returns_zero_for_identical_files(tmp_path):
+    file1 = tmp_path / "one.fits"
+    file2 = tmp_path / "two.fits"
+    diff_file = tmp_path / "diff.txt"
+    write_fits(file1, 1)
+    write_fits(file2, 1)
+
+    result = CliRunner().invoke(
+        cli, ["--file_pair", str(file1), str(file2), "--diff_file", str(diff_file)]
+    )
+
+    assert result.exit_code == 0
+
+
+def test_compare_fits_returns_nonzero_for_different_files(tmp_path):
+    file1 = tmp_path / "one.fits"
+    file2 = tmp_path / "two.fits"
+    diff_file = tmp_path / "diff.txt"
+    write_fits(file1, 1)
+    write_fits(file2, 2)
+
+    result = CliRunner().invoke(
+        cli, ["--file_pair", str(file1), str(file2), "--diff_file", str(diff_file)]
+    )
+
+    assert result.exit_code == 1
+    assert "Data contains differences" in diff_file.read_text()


### PR DESCRIPTION
Make v2dl3-compareFitsFiles return a nonzero status when FITS files differ, while preserving the existing FITSDiff report.
Adds regression tests for identical and unequal files.