### PR TITLE
FITS corrections: MJD should be an integer, DISP metdata.

### DIFF
--- a/pyV2DL3/fillEVENTS.py
+++ b/pyV2DL3/fillEVENTS.py
@@ -109,7 +109,7 @@ def fillEVENTS(datasource, save_multiplicity=False, instrument_epoch=None, event
     hdu1.header.set("TSTOP   ", evt_dict["TSTOP"], "mission time of end of obs [s]")
     hdu1.header.set(
         "MJDREFI ",
-        constant.VTS_REFERENCE_MJD,
+        int(constant.VTS_REFERENCE_MJD),
         "int part of reference MJD [days]",
     )
     hdu1.header.set("MJDREFF ", 0.0, "fractional part of reference MJD [days]")

--- a/pyV2DL3/fillGTI.py
+++ b/pyV2DL3/fillGTI.py
@@ -23,7 +23,7 @@ def fillGTI(datasource, goodTimeStart=None, goodTimeStop=None):
     hdu2.header.set("TSTART", startTime_s, "start time [s]")
     hdu2.header.set("TSTOP", endTime_s, "stop time same [s]")
 
-    hdu2.header.set("MJDREFI ", VTS_REFERENCE_MJD, "int part of reference MJD [days]")
+    hdu2.header.set("MJDREFI ", int(VTS_REFERENCE_MJD), "int part of reference MJD [days]")
     hdu2.header.set("MJDREFF ", 0.0, "fractional part of reference MJD [days]")
 
     hdu2.header.set("TIMEUNIT", "s", "time unit is seconds since MET start")

--- a/pyV2DL3/fillRESPONSE.py
+++ b/pyV2DL3/fillRESPONSE.py
@@ -45,7 +45,7 @@ def fill_bintablehdu(
         hdu.header.set("TUNIT5 ", "deg", "")
         hdu.header.set("TUNIT6 ", "deg", "")
         hdu.header.set(
-            "CREF7", "(ETRUE_LO:ETRUE_HI,MIGRA_LO:MIGRA_HI,THETA_LO:THETA_HI)", ""
+            "CREF7", "(ENERG_LO:ENERG_HI,MIGRA_LO:MIGRA_HI,THETA_LO:THETA_HI)", ""
         )
     # PSF
     elif hdu_name == "PSF":


### PR DESCRIPTION
Two corrections which change the FITS output:

1. The shared EDISP FITS writer declares the energy-axis columns incorrectly in the `CREF7` header. It currently refers to `ETRUE_LO` and `ETRUE_HI`, while both Eventdisplay and VEGAS EDISP tables actually store these columns as `ENERG_LO` and `ENERG_HI`.

This change aligns the header metadata with the existing table schema:

```text
Before: (ETRUE_LO:ETRUE_HI,MIGRA_LO:MIGRA_HI,THETA_LO:THETA_HI)
After:  (ENERG_LO:ENERG_HI,MIGRA_LO:MIGRA_HI,THETA_LO:THETA_HI)
```

2. MJD should be an integer according to [GDAF](https://gamma-astro-data-formats.readthedocs.io/en/v0.3/general/time.html?highlight=mjd), but V2DL3 stores it as float. Changes this to be integers.

This will change the FITS files slightly, therefore test files needs to be replaced.